### PR TITLE
feat: Simplify state workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ This project follows a **feature-based package structure** rather than tradition
   - `ui/`: QuoteListView, QuoteFormDialog
 
 - **`fr.axl.lvy.order`**: Order management
-  - `OrderCodig.kt`: Customer order (CONFIRMED → IN_PRODUCTION → READY → DELIVERED → INVOICED)
-  - `OrderNetstone.kt`: Supplier/MTO order (SENT → CONFIRMED → IN_PRODUCTION → RECEIVED)
+  - `OrderCodig.kt`: Customer order (DRAFT → CONFIRMED → DELIVERED → INVOICED or CANCELLED)
+  - `OrderNetstone.kt`: Supplier/MTO order (SENT → CONFIRMED → RECEIVED or CANCELLED)
   - Services with state machines, duplicate(), handleMto()
   - `ui/`: CommandCodigListView, CommandCodigFormDialog, CommandNetstoneListView, CommandNetstoneFormDialog
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,8 @@ This project follows a **feature-based package structure** rather than tradition
   - `ui/`: QuoteListView, QuoteFormDialog
 
 - **`fr.axl.lvy.order`**: Order management
-  - `OrderCodig.kt`: Customer order (CONFIRMED → IN_PRODUCTION → READY → DELIVERED → INVOICED)
-  - `OrderNetstone.kt`: Supplier/MTO order (SENT → CONFIRMED → IN_PRODUCTION → RECEIVED)
+  - `OrderCodig.kt`: Customer order (DRAFT → CONFIRMED → DELIVERED → INVOICED or CANCELLED)
+  - `OrderNetstone.kt`: Supplier/MTO order (SENT → CONFIRMED → RECEIVED or CANCELLED)
   - Services with state machines, duplicate(), handleMto()
   - `ui/`: CommandCodigListView, CommandCodigFormDialog, CommandNetstoneListView, CommandNetstoneFormDialog
 

--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodig.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodig.kt
@@ -14,7 +14,7 @@ import org.hibernate.type.SqlTypes
 
 /**
  * A customer purchase order managed by Codig. Follows a status workflow: DRAFT -> CONFIRMED ->
- * IN_PRODUCTION -> READY -> DELIVERED -> INVOICED (or CANCELLED at most stages).
+ * DELIVERED -> INVOICED (or CANCELLED at most stages).
  *
  * When the order contains MTO products, a linked [OrderNetstone] is created to place the
  * corresponding supplier order. A [sourceOrder] link tracks duplicated orders.
@@ -29,13 +29,7 @@ class OrderCodig(
   @Column(name = "order_date", nullable = false) var orderDate: LocalDate,
 ) : CodigDocument(client) {
   companion object {
-    private val EDITABLE =
-      setOf(
-        OrderCodigStatus.DRAFT,
-        OrderCodigStatus.CONFIRMED,
-        OrderCodigStatus.IN_PRODUCTION,
-        OrderCodigStatus.READY,
-      )
+    private val EDITABLE = setOf(OrderCodigStatus.DRAFT, OrderCodigStatus.CONFIRMED)
   }
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -46,8 +40,7 @@ class OrderCodig(
   @JdbcTypeCode(SqlTypes.VARCHAR)
   @Column(
     nullable = false,
-    columnDefinition =
-      "enum('DRAFT','CONFIRMED','IN_PRODUCTION','READY','DELIVERED','INVOICED','CANCELLED')",
+    columnDefinition = "enum('DRAFT','CONFIRMED','DELIVERED','INVOICED','CANCELLED')",
   )
   var status: OrderCodigStatus = OrderCodigStatus.DRAFT
 
@@ -80,8 +73,6 @@ class OrderCodig(
   enum class OrderCodigStatus {
     DRAFT,
     CONFIRMED,
-    IN_PRODUCTION,
-    READY,
     DELIVERED,
     INVOICED,
     CANCELLED,

--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
@@ -30,10 +30,6 @@ class OrderCodigService(
     private val ALLOWED_TRANSITIONS_FROM_DRAFT =
       setOf(OrderCodig.OrderCodigStatus.CONFIRMED, OrderCodig.OrderCodigStatus.CANCELLED)
     private val ALLOWED_TRANSITIONS_FROM_CONFIRMED =
-      setOf(OrderCodig.OrderCodigStatus.IN_PRODUCTION, OrderCodig.OrderCodigStatus.CANCELLED)
-    private val ALLOWED_TRANSITIONS_FROM_IN_PRODUCTION =
-      setOf(OrderCodig.OrderCodigStatus.READY, OrderCodig.OrderCodigStatus.CANCELLED)
-    private val ALLOWED_TRANSITIONS_FROM_READY =
       setOf(OrderCodig.OrderCodigStatus.DELIVERED, OrderCodig.OrderCodigStatus.CANCELLED)
     private val ALLOWED_TRANSITIONS_FROM_DELIVERED = setOf(OrderCodig.OrderCodigStatus.INVOICED)
   }
@@ -229,8 +225,6 @@ class OrderCodigService(
     when (current) {
       OrderCodig.OrderCodigStatus.DRAFT -> ALLOWED_TRANSITIONS_FROM_DRAFT
       OrderCodig.OrderCodigStatus.CONFIRMED -> ALLOWED_TRANSITIONS_FROM_CONFIRMED
-      OrderCodig.OrderCodigStatus.IN_PRODUCTION -> ALLOWED_TRANSITIONS_FROM_IN_PRODUCTION
-      OrderCodig.OrderCodigStatus.READY -> ALLOWED_TRANSITIONS_FROM_READY
       OrderCodig.OrderCodigStatus.DELIVERED -> ALLOWED_TRANSITIONS_FROM_DELIVERED
       else -> emptySet()
     }

--- a/src/main/kotlin/fr/axl/lvy/order/OrderNetstone.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderNetstone.kt
@@ -10,7 +10,7 @@ import org.hibernate.type.SqlTypes
 
 /**
  * A supplier purchase order placed by Netstone, always linked to a parent [OrderCodig]. Follows a
- * status workflow: SENT -> CONFIRMED -> IN_PRODUCTION -> RECEIVED (or CANCELLED).
+ * status workflow: SENT -> CONFIRMED -> RECEIVED (or CANCELLED).
  *
  * Tracks reception details (date, conformity, reserves) when goods arrive.
  */
@@ -26,10 +26,7 @@ class OrderNetstone(
 ) : TotalizableDocument() {
   @Enumerated(EnumType.STRING)
   @JdbcTypeCode(SqlTypes.VARCHAR)
-  @Column(
-    nullable = false,
-    columnDefinition = "enum('SENT','CONFIRMED','IN_PRODUCTION','RECEIVED','CANCELLED')",
-  )
+  @Column(nullable = false, columnDefinition = "enum('SENT','CONFIRMED','RECEIVED','CANCELLED')")
   var status: OrderNetstoneStatus = OrderNetstoneStatus.SENT
 
   @Column(name = "order_date") var orderDate: LocalDate? = null
@@ -48,7 +45,6 @@ class OrderNetstone(
   enum class OrderNetstoneStatus {
     SENT,
     CONFIRMED,
-    IN_PRODUCTION,
     RECEIVED,
     CANCELLED,
   }

--- a/src/main/kotlin/fr/axl/lvy/order/OrderNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderNetstoneService.kt
@@ -25,11 +25,6 @@ class OrderNetstoneService(
         OrderNetstone.OrderNetstoneStatus.CANCELLED,
       )
     private val ALLOWED_TRANSITIONS_FROM_CONFIRMED =
-      setOf(
-        OrderNetstone.OrderNetstoneStatus.IN_PRODUCTION,
-        OrderNetstone.OrderNetstoneStatus.CANCELLED,
-      )
-    private val ALLOWED_TRANSITIONS_FROM_IN_PRODUCTION =
       setOf(OrderNetstone.OrderNetstoneStatus.RECEIVED, OrderNetstone.OrderNetstoneStatus.CANCELLED)
   }
 
@@ -102,7 +97,6 @@ class OrderNetstoneService(
     when (current) {
       OrderNetstone.OrderNetstoneStatus.SENT -> ALLOWED_TRANSITIONS_FROM_SENT
       OrderNetstone.OrderNetstoneStatus.CONFIRMED -> ALLOWED_TRANSITIONS_FROM_CONFIRMED
-      OrderNetstone.OrderNetstoneStatus.IN_PRODUCTION -> ALLOWED_TRANSITIONS_FROM_IN_PRODUCTION
       else -> emptySet()
     }
 

--- a/src/main/kotlin/fr/axl/lvy/seed/DatabaseSeeder.kt
+++ b/src/main/kotlin/fr/axl/lvy/seed/DatabaseSeeder.kt
@@ -335,7 +335,7 @@ class DatabaseSeeder(
       "[Seeder] Created order Codig: ${savedOrder1.orderNumber} for ${acme.name} (CONFIRMED)"
     )
 
-    // Order 2: Dupont, IN_PRODUCTION, widgets + consulting
+    // Order 2: Dupont, CONFIRMED, widgets + consulting
     val order2 =
       OrderCodig("", dupont, LocalDate.now().minusDays(20)).apply {
         subject = "Widgets + consulting mission"
@@ -359,10 +359,8 @@ class DatabaseSeeder(
       )
     var savedOrder2 = orderCodigService.saveWithLines(order2, order2Lines)
     savedOrder2 = orderCodigService.changeStatus(savedOrder2, OrderCodig.OrderCodigStatus.CONFIRMED)
-    savedOrder2 =
-      orderCodigService.changeStatus(savedOrder2, OrderCodig.OrderCodigStatus.IN_PRODUCTION)
     logger.info(
-      "[Seeder] Created order Codig: ${savedOrder2.orderNumber} for ${dupont.name} (IN_PRODUCTION)"
+      "[Seeder] Created order Codig: ${savedOrder2.orderNumber} for ${dupont.name} (CONFIRMED)"
     )
   }
 

--- a/src/test/kotlin/fr/axl/lvy/order/OrderCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/order/OrderCodigServiceTest.kt
@@ -74,38 +74,34 @@ class OrderCodigServiceTest {
   }
 
   @Test
-  fun isEditable_for_confirmed_in_production_ready() {
+  fun isEditable_for_draft_and_confirmed() {
     val client = testData.createClient("CLI-OA03")
 
+    assertThat(createOrderCodig("CA-E1", client, OrderCodig.OrderCodigStatus.DRAFT).isEditable())
+      .isTrue
     assertThat(
-        createOrderCodig("CA-E1", client, OrderCodig.OrderCodigStatus.CONFIRMED).isEditable()
+        createOrderCodig("CA-E2", client, OrderCodig.OrderCodigStatus.CONFIRMED).isEditable()
       )
       .isTrue
     assertThat(
-        createOrderCodig("CA-E2", client, OrderCodig.OrderCodigStatus.IN_PRODUCTION).isEditable()
-      )
-      .isTrue
-    assertThat(createOrderCodig("CA-E3", client, OrderCodig.OrderCodigStatus.READY).isEditable())
-      .isTrue
-    assertThat(
-        createOrderCodig("CA-E4", client, OrderCodig.OrderCodigStatus.DELIVERED).isEditable()
+        createOrderCodig("CA-E3", client, OrderCodig.OrderCodigStatus.DELIVERED).isEditable()
       )
       .isFalse
-    assertThat(createOrderCodig("CA-E5", client, OrderCodig.OrderCodigStatus.INVOICED).isEditable())
+    assertThat(createOrderCodig("CA-E4", client, OrderCodig.OrderCodigStatus.INVOICED).isEditable())
       .isFalse
     assertThat(
-        createOrderCodig("CA-E6", client, OrderCodig.OrderCodigStatus.CANCELLED).isEditable()
+        createOrderCodig("CA-E5", client, OrderCodig.OrderCodigStatus.CANCELLED).isEditable()
       )
       .isFalse
   }
 
   @Test
-  fun status_transition_confirmed_to_in_production() {
+  fun status_transition_confirmed_to_delivered() {
     val client = testData.createClient("CLI-OA04")
     val order = createOrderCodig("CA-ST-01", client, OrderCodig.OrderCodigStatus.CONFIRMED)
 
-    val updated = orderCodigService.changeStatus(order, OrderCodig.OrderCodigStatus.IN_PRODUCTION)
-    assertThat(updated.status).isEqualTo(OrderCodig.OrderCodigStatus.IN_PRODUCTION)
+    val updated = orderCodigService.changeStatus(order, OrderCodig.OrderCodigStatus.DELIVERED)
+    assertThat(updated.status).isEqualTo(OrderCodig.OrderCodigStatus.DELIVERED)
   }
 
   @Test
@@ -246,24 +242,6 @@ class OrderCodigServiceTest {
     assertThat(saved.totalExclTax).isEqualByComparingTo("100.00")
     val salesNetstone = salesNetstoneRepository.findBySalesCodigId(salesCodig.id!!)
     assertThat(salesNetstone).isNull()
-  }
-
-  @Test
-  fun status_transition_in_production_to_ready() {
-    val client = testData.createClient("CLI-OA05")
-    val order = createOrderCodig("CA-ST-02", client, OrderCodig.OrderCodigStatus.IN_PRODUCTION)
-
-    val updated = orderCodigService.changeStatus(order, OrderCodig.OrderCodigStatus.READY)
-    assertThat(updated.status).isEqualTo(OrderCodig.OrderCodigStatus.READY)
-  }
-
-  @Test
-  fun status_transition_ready_to_delivered() {
-    val client = testData.createClient("CLI-OA06")
-    val order = createOrderCodig("CA-ST-03", client, OrderCodig.OrderCodigStatus.READY)
-
-    val updated = orderCodigService.changeStatus(order, OrderCodig.OrderCodigStatus.DELIVERED)
-    assertThat(updated.status).isEqualTo(OrderCodig.OrderCodigStatus.DELIVERED)
   }
 
   @Test

--- a/src/test/kotlin/fr/axl/lvy/order/OrderNetstoneServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/order/OrderNetstoneServiceTest.kt
@@ -77,24 +77,10 @@ class OrderNetstoneServiceTest {
   }
 
   @Test
-  fun status_transition_confirmed_to_in_production() {
+  fun status_transition_confirmed_to_received() {
     val orderCodig = createOrderCodig("CA-OB-04")
     val orderNetstone =
       createOrderNetstone("CB-ST-02", orderCodig, OrderNetstone.OrderNetstoneStatus.CONFIRMED)
-
-    val updated =
-      orderNetstoneService.changeStatus(
-        orderNetstone,
-        OrderNetstone.OrderNetstoneStatus.IN_PRODUCTION,
-      )
-    assertThat(updated.status).isEqualTo(OrderNetstone.OrderNetstoneStatus.IN_PRODUCTION)
-  }
-
-  @Test
-  fun status_transition_in_production_to_received() {
-    val orderCodig = createOrderCodig("CA-OB-05")
-    val orderNetstone =
-      createOrderNetstone("CB-ST-03", orderCodig, OrderNetstone.OrderNetstoneStatus.IN_PRODUCTION)
 
     val updated =
       orderNetstoneService.changeStatus(orderNetstone, OrderNetstone.OrderNetstoneStatus.RECEIVED)
@@ -143,7 +129,7 @@ class OrderNetstoneServiceTest {
   fun markReceived_sets_reception_data() {
     val orderCodig = createOrderCodig("CA-OB-08")
     val orderNetstone =
-      createOrderNetstone("CB-REC-01", orderCodig, OrderNetstone.OrderNetstoneStatus.IN_PRODUCTION)
+      createOrderNetstone("CB-REC-01", orderCodig, OrderNetstone.OrderNetstoneStatus.CONFIRMED)
 
     val received =
       orderNetstoneService.markReceived(

--- a/src/test/kotlin/fr/axl/lvy/seed/DatabaseSeederTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/seed/DatabaseSeederTest.kt
@@ -60,7 +60,7 @@ class DatabaseSeederTest {
     val orders = orderCodigRepository.findAll()
     assertThat(orders).hasSizeGreaterThanOrEqualTo(2)
     assertThat(orders.map { it.status })
-      .contains(OrderCodig.OrderCodigStatus.DRAFT, OrderCodig.OrderCodigStatus.IN_PRODUCTION)
+      .contains(OrderCodig.OrderCodigStatus.DRAFT, OrderCodig.OrderCodigStatus.CONFIRMED)
   }
 
   @Test


### PR DESCRIPTION
- Remove IN_PRODUCTION and READY from OrderCodigStatus — workflow is now DRAFT → CONFIRMED → DELIVERED → INVOICED (or CANCELLED)                                                                                                                                                                                  
- Remove IN_PRODUCTION from OrderNetstoneStatus — workflow is now SENT → CONFIRMED → RECEIVED (or CANCELLED)
- Update state machine transitions, EDITABLE set, database enum column definitions, seeder, tests, and docs accordingly 