### PR TITLE
feat: Fix Netstone PDF layout, supplier data, and logo r

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/base/DocumentLineSchemaUpdater.kt
+++ b/src/main/kotlin/fr/axl/lvy/base/DocumentLineSchemaUpdater.kt
@@ -1,0 +1,68 @@
+package fr.axl.lvy.base
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * Keeps the development MySQL enum/check constraint aligned while the project still runs without
+ * migrations. Hibernate update does not reliably expand existing check constraints.
+ */
+@Component
+class DocumentLineSchemaUpdater(private val jdbcTemplate: JdbcTemplate) : ApplicationRunner {
+
+  override fun run(args: ApplicationArguments) {
+    if (!isMySql()) return
+
+    val constraints =
+      jdbcTemplate.queryForList(
+        """
+          SELECT tc.CONSTRAINT_NAME
+          FROM information_schema.TABLE_CONSTRAINTS tc
+          JOIN information_schema.CHECK_CONSTRAINTS cc
+            ON cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
+           AND cc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+          WHERE tc.TABLE_SCHEMA = DATABASE()
+            AND tc.TABLE_NAME = 'document_lines'
+            AND tc.CONSTRAINT_TYPE = 'CHECK'
+            AND LOWER(cc.CHECK_CLAUSE) LIKE '%document_type%'
+        """,
+        String::class.java,
+      )
+
+    val expectedValues =
+      listOf(
+        "SALES_CODIG",
+        "SALES_NETSTONE",
+        "ORDER_CODIG",
+        "ORDER_NETSTONE",
+        "DELIVERY_NETSTONE",
+        "INVOICE_CODIG",
+        "INVOICE_NETSTONE",
+      )
+    val expectedCheck =
+      expectedValues.joinToString(prefix = "document_type IN (", postfix = ")") { "'$it'" }
+
+    constraints.forEach { constraint ->
+      jdbcTemplate.execute("ALTER TABLE document_lines DROP CHECK `$constraint`")
+    }
+    jdbcTemplate.execute(
+      "ALTER TABLE document_lines ADD CONSTRAINT document_lines_document_type_chk CHECK ($expectedCheck)"
+    )
+    log.info("Document line document_type check constraint aligned")
+  }
+
+  private fun isMySql(): Boolean =
+    runCatching {
+        jdbcTemplate.dataSource?.connection?.use { connection ->
+          connection.metaData.databaseProductName.contains("MySQL", ignoreCase = true)
+        } == true
+      }
+      .getOrDefault(false)
+
+  companion object {
+    private val log = LoggerFactory.getLogger(DocumentLineSchemaUpdater::class.java)
+  }
+}

--- a/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
+++ b/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
@@ -26,6 +26,14 @@ class NumberSequenceService(
     return nextNumber(entityType, config.prefix, config.padding)
   }
 
+  @Transactional(readOnly = true)
+  fun previewNextNumber(entityType: String): String {
+    val config =
+      CONFIGS[entityType] ?: throw IllegalArgumentException("Unknown entity type: $entityType")
+    val current = repository.findById(entityType).map { it.nextVal }.orElse(1)
+    return config.prefix + current.toString().padStart(config.padding, '0')
+  }
+
   @Transactional
   fun nextNumber(entityType: String, prefix: String, padding: Int): String {
     val seq = repository.findForUpdate(entityType) ?: repository.save(NumberSequence(entityType))
@@ -45,6 +53,7 @@ class NumberSequenceService(
     const val SALES_CODIG = "SALES_CODIG"
     const val SALES_NETSTONE = "SALES_NETSTONE"
     const val DELIVERY_CODIG = "DELIVERY_CODIG"
+    const val DELIVERY_NETSTONE = "DELIVERY_NETSTONE"
 
     val CONFIGS =
       mapOf(
@@ -54,6 +63,7 @@ class NumberSequenceService(
         SALES_CODIG to SequenceConfig("CoD_SO_", 3),
         SALES_NETSTONE to SequenceConfig("NST_SO_", 3),
         DELIVERY_CODIG to SequenceConfig("BL-", 6),
+        DELIVERY_NETSTONE to SequenceConfig("Netst/OUT/", 3),
       )
   }
 }

--- a/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
+++ b/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
@@ -62,7 +62,7 @@ class NumberSequenceService(
         ORDER_NETSTONE to SequenceConfig("NST_PO_", 3),
         SALES_CODIG to SequenceConfig("CoD_SO_", 3),
         SALES_NETSTONE to SequenceConfig("NST_SO_", 3),
-        DELIVERY_CODIG to SequenceConfig("BL-", 6),
+        DELIVERY_CODIG to SequenceConfig("CoD/OUT/", 3),
         DELIVERY_NETSTONE to SequenceConfig("Netst/OUT/", 3),
       )
   }

--- a/src/main/kotlin/fr/axl/lvy/client/ui/ClientFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/client/ui/ClientFormDialog.kt
@@ -387,7 +387,7 @@ internal class ClientFormDialog(
   }
 
   private fun configureLogoUpload() {
-    logoUpload.setAcceptedFileTypes("image/png", "image/jpeg", "image/webp", "image/svg+xml")
+    logoUpload.setAcceptedFileTypes("image/png", "image/jpeg")
     logoUpload.setMaxFiles(1)
     logoUpload.isDropAllowed = true
     logoPreview.setAlt("Logo de la société")

--- a/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodig.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodig.kt
@@ -11,9 +11,7 @@ import org.hibernate.type.SqlTypes
 
 /**
  * A delivery note for goods shipped to a customer (Codig side). Linked to the originating
- * [OrderCodig]. Tracks shipping, carrier, and proof of delivery.
- *
- * Status workflow: PREPARED -> SHIPPED -> DELIVERED (or INCIDENT at any stage).
+ * [OrderCodig]. Tracks delivery address and logistics references shared with Netstone deliveries.
  */
 @Entity
 @Table(name = "delivery_notes_codig")
@@ -44,6 +42,16 @@ class DeliveryNoteCodig(
   @Column(name = "tracking_number", length = 100) var trackingNumber: String? = null
 
   @Column(name = "package_count") var packageCount: Int? = null
+
+  @Column(name = "arrival_date") var arrivalDate: LocalDate? = null
+
+  @Column(name = "container_number", length = 50) var containerNumber: String? = null
+
+  @Column(name = "bill_of_lading", length = 100) var billOfLading: String? = null
+
+  @Column(length = 50) var lot: String? = null
+
+  @Column(length = 100) var seals: String? = null
 
   @Column(name = "signed_by", length = 100) var signedBy: String? = null
 

--- a/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstone.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstone.kt
@@ -38,6 +38,8 @@ class DeliveryNoteNetstone(
 
   @Column(name = "container_number", length = 50) var containerNumber: String? = null
 
+  @Column(name = "bill_of_lading", length = 100) var billOfLading: String? = null
+
   @Column(length = 50) var lot: String? = null
 
   @Column(length = 100) var seals: String? = null

--- a/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface DeliveryNoteNetstoneRepository : JpaRepository<DeliveryNoteNetstone, Long> {
   fun findByDeletedAtIsNull(): List<DeliveryNoteNetstone>
+
+  fun findByOrderNetstoneIdAndDeletedAtIsNull(orderNetstoneId: Long): DeliveryNoteNetstone?
 }

--- a/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneService.kt
@@ -1,0 +1,75 @@
+package fr.axl.lvy.delivery
+
+import fr.axl.lvy.base.NumberSequenceService
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.DocumentLineService
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.Optional
+import org.slf4j.LoggerFactory
+import org.slf4j.MDC
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/** Manages Netstone delivery notes and their delivered product lines. */
+@Service
+class DeliveryNoteNetstoneService(
+  private val deliveryNoteNetstoneRepository: DeliveryNoteNetstoneRepository,
+  private val documentLineService: DocumentLineService,
+  private val numberSequenceService: NumberSequenceService,
+  private val meterRegistry: MeterRegistry,
+) {
+  private val deliveriesCreatedCounter = meterRegistry.counter("delivery.netstone")
+
+  companion object {
+    private val log = LoggerFactory.getLogger(DeliveryNoteNetstoneService::class.java)
+  }
+
+  @Transactional(readOnly = true)
+  fun findById(id: Long): Optional<DeliveryNoteNetstone> =
+    deliveryNoteNetstoneRepository.findById(id)
+
+  @Transactional(readOnly = true)
+  fun findByOrderNetstoneId(orderNetstoneId: Long): DeliveryNoteNetstone? =
+    deliveryNoteNetstoneRepository.findByOrderNetstoneIdAndDeletedAtIsNull(orderNetstoneId)
+
+  @Transactional(readOnly = true)
+  fun findLines(noteId: Long): List<DocumentLine> =
+    documentLineService.findLines(DocumentLine.DocumentType.DELIVERY_NETSTONE, noteId)
+
+  @Transactional(readOnly = true)
+  fun previewNextDeliveryNoteNumber(): String =
+    numberSequenceService.previewNextNumber(NumberSequenceService.DELIVERY_NETSTONE)
+
+  @Transactional
+  fun save(note: DeliveryNoteNetstone): DeliveryNoteNetstone {
+    val isNew = note.deliveryNoteNumber.isBlank()
+    if (isNew) {
+      note.deliveryNoteNumber =
+        numberSequenceService.nextNumber(NumberSequenceService.DELIVERY_NETSTONE)
+    }
+    val saved = deliveryNoteNetstoneRepository.save(note)
+    if (isNew) {
+      deliveriesCreatedCounter.increment()
+      MDC.put("deliveryNoteNumber", saved.deliveryNoteNumber)
+      MDC.put("orderNumber", saved.orderNetstone.orderNumber)
+      try {
+        log.info(
+          "DeliveryNoteNetstone {} created for order {}",
+          saved.deliveryNoteNumber,
+          saved.orderNetstone.orderNumber,
+        )
+      } finally {
+        MDC.remove("deliveryNoteNumber")
+        MDC.remove("orderNumber")
+      }
+    }
+    return saved
+  }
+
+  @Transactional
+  fun saveWithLines(note: DeliveryNoteNetstone, lines: List<DocumentLine>): DeliveryNoteNetstone {
+    val saved = save(note)
+    documentLineService.replaceLines(DocumentLine.DocumentType.DELIVERY_NETSTONE, saved.id!!, lines)
+    return saved
+  }
+}

--- a/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteCodigFormDialog.kt
@@ -2,38 +2,43 @@ package fr.axl.lvy.delivery.ui
 
 import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.button.ButtonVariant
-import com.vaadin.flow.component.combobox.ComboBox
 import com.vaadin.flow.component.datepicker.DatePicker
 import com.vaadin.flow.component.dialog.Dialog
 import com.vaadin.flow.component.formlayout.FormLayout
+import com.vaadin.flow.component.html.Anchor
 import com.vaadin.flow.component.notification.Notification
 import com.vaadin.flow.component.notification.NotificationVariant
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
-import com.vaadin.flow.component.textfield.IntegerField
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.server.StreamResource
 import fr.axl.lvy.delivery.DeliveryNoteCodig
 import fr.axl.lvy.delivery.DeliveryNoteCodigService
+import fr.axl.lvy.delivery.DeliveryNoteNetstone
 import fr.axl.lvy.order.OrderCodig
+import fr.axl.lvy.pdf.PdfService
 
 internal class DeliveryNoteCodigFormDialog(
   private val deliveryNoteCodigService: DeliveryNoteCodigService,
+  private val pdfService: PdfService,
   private val orderCodig: OrderCodig,
+  private val saleNumber: String,
+  private val clientReference: String?,
+  private val netstoneDeliveryNote: DeliveryNoteNetstone?,
   private val note: DeliveryNoteCodig?,
   private val onSave: Runnable,
 ) : Dialog() {
 
   private val noteNumber = TextField("N° Livraison")
-  private val status = ComboBox<DeliveryNoteCodig.DeliveryNoteCodigStatus>("Statut")
-  private val shippingDate = DatePicker("Date expédition")
-  private val deliveryDate = DatePicker("Date livraison")
+  private val saleDocumentNumber = TextField("Vente CoDIG")
+  private val customerReference = TextField("Réf. client")
   private val shippingAddress = TextArea("Adresse livraison")
-  private val carrier = TextField("Transporteur")
-  private val trackingNumber = TextField("N° suivi")
-  private val packageCount = IntegerField("Nombre de colis")
-  private val signedBy = TextField("Signé par")
-  private val signatureDate = DatePicker("Date signature")
+  private val arrivalDate = DatePicker("Date arrivée")
+  private val containerNumber = TextField("N° conteneur")
+  private val billOfLading = TextField("BL")
+  private val lot = TextField("Lot")
+  private val seals = TextField("Scellés")
   private val observations = TextArea("Observations")
 
   init {
@@ -41,24 +46,19 @@ internal class DeliveryNoteCodigFormDialog(
     width = "760px"
 
     noteNumber.isReadOnly = true
-    status.setItems(*DeliveryNoteCodig.DeliveryNoteCodigStatus.entries.toTypedArray())
-    status.setItemLabelGenerator {
-      when (it) {
-        DeliveryNoteCodig.DeliveryNoteCodigStatus.PREPARED -> "Préparée"
-        DeliveryNoteCodig.DeliveryNoteCodigStatus.SHIPPED -> "Expédiée"
-        DeliveryNoteCodig.DeliveryNoteCodigStatus.DELIVERED -> "Livrée"
-        DeliveryNoteCodig.DeliveryNoteCodigStatus.INCIDENT -> "Incident"
-      }
-    }
+    saleDocumentNumber.isReadOnly = true
+    saleDocumentNumber.value = saleNumber
+    customerReference.isReadOnly = true
+    customerReference.value = clientReference ?: ""
 
     val form = FormLayout()
     form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
-    form.add(noteNumber, status)
-    form.add(shippingDate, deliveryDate)
-    form.add(carrier, trackingNumber)
-    form.add(packageCount, signedBy)
-    form.add(signatureDate)
+    form.add(noteNumber, saleDocumentNumber)
+    form.add(customerReference, 2)
     form.add(shippingAddress, 2)
+    form.add(arrivalDate, containerNumber)
+    form.add(billOfLading, lot)
+    form.add(seals)
     form.add(observations, 2)
 
     add(VerticalLayout(form).apply { isPadding = false })
@@ -66,42 +66,72 @@ internal class DeliveryNoteCodigFormDialog(
     val saveBtn = Button("Enregistrer") { save() }
     saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
     val cancelBtn = Button("Annuler") { close() }
-    footer.add(HorizontalLayout(saveBtn, cancelBtn))
+    val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
+    if (note?.id != null) {
+      val pdfResource =
+        StreamResource("${note.deliveryNoteNumber.replace("/", "_")}.pdf") {
+            pdfService.generateDeliveryCodigPdf(note.id!!).inputStream()
+          }
+          .apply { cacheTime = 0 }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink =
+        Anchor(pdfResource, "").apply {
+          element.setAttribute("download", true)
+          add(pdfBtn)
+        }
+      footerLayout.add(pdfLink)
+    }
+    footer.add(footerLayout)
 
     if (note != null) {
       populateForm(note)
     } else {
       noteNumber.value = "(auto)"
-      status.value = DeliveryNoteCodig.DeliveryNoteCodigStatus.PREPARED
       shippingAddress.value = orderCodig.shippingAddress ?: ""
+      populateLogisticsFromNetstone()
     }
   }
 
   private fun populateForm(note: DeliveryNoteCodig) {
     noteNumber.value = note.deliveryNoteNumber
-    status.value = note.status
-    shippingDate.value = note.shippingDate
-    deliveryDate.value = note.deliveryDate
     shippingAddress.value = note.shippingAddress ?: ""
-    carrier.value = note.carrier ?: ""
-    trackingNumber.value = note.trackingNumber ?: ""
-    packageCount.value = note.packageCount
-    signedBy.value = note.signedBy ?: ""
-    signatureDate.value = note.signatureDate
+    arrivalDate.value = note.arrivalDate
+    containerNumber.value = note.containerNumber ?: ""
+    billOfLading.value = note.billOfLading ?: ""
+    lot.value = note.lot ?: ""
+    seals.value = note.seals ?: ""
     observations.value = note.observations ?: ""
+    populateMissingLogisticsFromNetstone(note)
+  }
+
+  private fun populateLogisticsFromNetstone() {
+    arrivalDate.value = netstoneDeliveryNote?.arrivalDate
+    containerNumber.value = netstoneDeliveryNote?.containerNumber ?: ""
+    billOfLading.value = netstoneDeliveryNote?.billOfLading ?: ""
+    lot.value = netstoneDeliveryNote?.lot ?: ""
+    seals.value = netstoneDeliveryNote?.seals ?: ""
+  }
+
+  private fun populateMissingLogisticsFromNetstone(note: DeliveryNoteCodig) {
+    if (note.arrivalDate == null) arrivalDate.value = netstoneDeliveryNote?.arrivalDate
+    if (note.containerNumber.isNullOrBlank()) {
+      containerNumber.value = netstoneDeliveryNote?.containerNumber ?: ""
+    }
+    if (note.billOfLading.isNullOrBlank()) {
+      billOfLading.value = netstoneDeliveryNote?.billOfLading ?: ""
+    }
+    if (note.lot.isNullOrBlank()) lot.value = netstoneDeliveryNote?.lot ?: ""
+    if (note.seals.isNullOrBlank()) seals.value = netstoneDeliveryNote?.seals ?: ""
   }
 
   private fun save() {
     val deliveryNote = note ?: DeliveryNoteCodig("", orderCodig, orderCodig.client)
-    deliveryNote.status = status.value ?: DeliveryNoteCodig.DeliveryNoteCodigStatus.PREPARED
-    deliveryNote.shippingDate = shippingDate.value
-    deliveryNote.deliveryDate = deliveryDate.value
     deliveryNote.shippingAddress = shippingAddress.value.takeIf { it.isNotBlank() }
-    deliveryNote.carrier = carrier.value.takeIf { it.isNotBlank() }
-    deliveryNote.trackingNumber = trackingNumber.value.takeIf { it.isNotBlank() }
-    deliveryNote.packageCount = packageCount.value
-    deliveryNote.signedBy = signedBy.value.takeIf { it.isNotBlank() }
-    deliveryNote.signatureDate = signatureDate.value
+    deliveryNote.arrivalDate = arrivalDate.value
+    deliveryNote.containerNumber = containerNumber.value.takeIf { it.isNotBlank() }
+    deliveryNote.billOfLading = billOfLading.value.takeIf { it.isNotBlank() }
+    deliveryNote.lot = lot.value.takeIf { it.isNotBlank() }
+    deliveryNote.seals = seals.value.takeIf { it.isNotBlank() }
     deliveryNote.observations = observations.value.takeIf { it.isNotBlank() }
 
     val saved = deliveryNoteCodigService.save(deliveryNote)

--- a/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteNetstoneFormDialog.kt
@@ -1,0 +1,136 @@
+package fr.axl.lvy.delivery.ui
+
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.button.ButtonVariant
+import com.vaadin.flow.component.datepicker.DatePicker
+import com.vaadin.flow.component.dialog.Dialog
+import com.vaadin.flow.component.formlayout.FormLayout
+import com.vaadin.flow.component.html.Anchor
+import com.vaadin.flow.component.notification.Notification
+import com.vaadin.flow.component.notification.NotificationVariant
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.component.textfield.TextArea
+import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.server.StreamResource
+import fr.axl.lvy.base.ui.noGap
+import fr.axl.lvy.delivery.DeliveryNoteNetstone
+import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.ui.DocumentLineEditor
+import fr.axl.lvy.order.OrderNetstone
+import fr.axl.lvy.pdf.PdfService
+import fr.axl.lvy.product.ProductService
+
+internal class DeliveryNoteNetstoneFormDialog(
+  private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
+  private val productService: ProductService,
+  private val pdfService: PdfService,
+  private val orderNetstone: OrderNetstone,
+  private val saleNumber: String,
+  private val deliveryAddress: String?,
+  private val note: DeliveryNoteNetstone?,
+  initialLines: List<DocumentLine>,
+  private val onSave: Runnable,
+) : Dialog() {
+
+  private val noteNumber = TextField("N° Livraison")
+  private val saleDocumentNumber = TextField("Vente Netstone")
+  private val shippingAddress = TextArea("Adresse livraison")
+  private val arrivalDate = DatePicker("Date arrivée")
+  private val containerNumber = TextField("N° conteneur")
+  private val billOfLading = TextField("BL")
+  private val lot = TextField("Lot")
+  private val seals = TextField("Scellés")
+  private val observations = TextArea("Observations")
+  private val lineEditor =
+    DocumentLineEditor(
+      productService = productService,
+      documentType = DocumentLine.DocumentType.DELIVERY_NETSTONE,
+      usePurchasePrice = true,
+      lineTaxMode = DocumentLineEditor.LineTaxMode.VAT,
+      showUnitPrice = false,
+      showTax = false,
+      showLineTotal = false,
+    )
+
+  init {
+    headerTitle = if (note == null) "Nouvelle livraison Netstone" else "Modifier livraison Netstone"
+    width = "960px"
+    height = "80%"
+
+    noteNumber.isReadOnly = true
+    saleDocumentNumber.isReadOnly = true
+    saleDocumentNumber.value = saleNumber
+    shippingAddress.isReadOnly = true
+    shippingAddress.value = deliveryAddress ?: ""
+
+    val form = FormLayout()
+    form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
+    form.add(noteNumber, saleDocumentNumber)
+    form.add(shippingAddress, 2)
+    form.add(arrivalDate, containerNumber)
+    form.add(billOfLading, lot)
+    form.add(seals)
+    form.add(observations, 2)
+
+    lineEditor.setLines(initialLines)
+    val content = VerticalLayout(form, lineEditor)
+    content.noGap()
+    add(content)
+
+    val saveBtn = Button("Enregistrer") { save() }
+    saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
+    val cancelBtn = Button("Annuler") { close() }
+    val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
+    if (note?.id != null) {
+      val pdfResource =
+        StreamResource("${note.deliveryNoteNumber.replace("/", "_")}.pdf") {
+            pdfService.generateDeliveryNetstonePdf(note.id!!).inputStream()
+          }
+          .apply { cacheTime = 0 }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink =
+        Anchor(pdfResource, "").apply {
+          element.setAttribute("download", true)
+          add(pdfBtn)
+        }
+      footerLayout.add(pdfLink)
+    }
+    footer.add(footerLayout)
+
+    if (note != null) {
+      populateForm(note)
+    } else {
+      noteNumber.value = deliveryNoteNetstoneService.previewNextDeliveryNoteNumber()
+    }
+  }
+
+  private fun populateForm(note: DeliveryNoteNetstone) {
+    noteNumber.value = note.deliveryNoteNumber
+    arrivalDate.value = note.arrivalDate
+    containerNumber.value = note.containerNumber ?: ""
+    billOfLading.value = note.billOfLading ?: ""
+    lot.value = note.lot ?: ""
+    seals.value = note.seals ?: ""
+    observations.value = note.observations ?: ""
+  }
+
+  private fun save() {
+    val deliveryNote = note ?: DeliveryNoteNetstone("", orderNetstone)
+    deliveryNote.arrivalDate = arrivalDate.value
+    deliveryNote.containerNumber = containerNumber.value.takeIf { it.isNotBlank() }
+    deliveryNote.billOfLading = billOfLading.value.takeIf { it.isNotBlank() }
+    deliveryNote.lot = lot.value.takeIf { it.isNotBlank() }
+    deliveryNote.seals = seals.value.takeIf { it.isNotBlank() }
+    deliveryNote.observations = observations.value.takeIf { it.isNotBlank() }
+
+    val saved = deliveryNoteNetstoneService.saveWithLines(deliveryNote, lineEditor.getLines())
+    noteNumber.value = saved.deliveryNoteNumber
+
+    Notification.show("Livraison Netstone enregistrée", 3000, Notification.Position.BOTTOM_END)
+      .addThemeVariants(NotificationVariant.LUMO_SUCCESS)
+    onSave.run()
+    close()
+  }
+}

--- a/src/main/kotlin/fr/axl/lvy/documentline/DocumentLine.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/DocumentLine.kt
@@ -30,7 +30,7 @@ class DocumentLine(
     name = "document_type",
     nullable = false,
     columnDefinition =
-      "enum('SALES_CODIG','SALES_NETSTONE','ORDER_CODIG','ORDER_NETSTONE','INVOICE_CODIG','INVOICE_NETSTONE')",
+      "enum('SALES_CODIG','SALES_NETSTONE','ORDER_CODIG','ORDER_NETSTONE','DELIVERY_NETSTONE','INVOICE_CODIG','INVOICE_NETSTONE')",
   )
   var documentType: DocumentType,
   @Column(name = "document_id", nullable = false) var documentId: Long,
@@ -151,6 +151,7 @@ class DocumentLine(
     SALES_NETSTONE,
     ORDER_CODIG,
     ORDER_NETSTONE,
+    DELIVERY_NETSTONE,
     INVOICE_CODIG,
     INVOICE_NETSTONE,
   }

--- a/src/main/kotlin/fr/axl/lvy/documentline/ui/DocumentLineEditor.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/ui/DocumentLineEditor.kt
@@ -31,6 +31,9 @@ class DocumentLineEditor(
   private val usePurchasePrice: Boolean = false,
   private val lineTaxMode: LineTaxMode = LineTaxMode.DISCOUNT,
   private val defaultVatRate: BigDecimal = BigDecimal.ZERO,
+  private val showUnitPrice: Boolean = true,
+  private val showTax: Boolean = true,
+  private val showLineTotal: Boolean = true,
 ) : VerticalLayout() {
 
   private val lines = mutableListOf<DocumentLine>()
@@ -80,22 +83,24 @@ class DocumentLineEditor(
       }
       .setHeader("Unité")
       .setAutoWidth(true)
-    grid
-      .addComponentColumn { line ->
-        BigDecimalField().apply {
-          value = line.unitPriceExclTax
-          placeholder = "PU HT"
-          width = "140px"
-          valueChangeMode = ValueChangeMode.EAGER
-          addValueChangeListener {
-            line.unitPriceExclTax = it.value ?: BigDecimal.ZERO
-            line.recalculate()
-            refreshGrid()
+    if (showUnitPrice) {
+      grid
+        .addComponentColumn { line ->
+          BigDecimalField().apply {
+            value = line.unitPriceExclTax
+            placeholder = "PU HT"
+            width = "140px"
+            valueChangeMode = ValueChangeMode.EAGER
+            addValueChangeListener {
+              line.unitPriceExclTax = it.value ?: BigDecimal.ZERO
+              line.recalculate()
+              refreshGrid()
+            }
           }
         }
-      }
-      .setHeader("PU HT")
-      .setAutoWidth(true)
+        .setHeader("PU HT")
+        .setAutoWidth(true)
+    }
     if (currencySupplier != null && currencyUpdater != null) {
       grid
         .addComponentColumn {
@@ -113,43 +118,47 @@ class DocumentLineEditor(
         .setHeader("Devise")
         .setAutoWidth(true)
     }
-    when (lineTaxMode) {
-      LineTaxMode.DISCOUNT ->
-        grid
-          .addComponentColumn { line ->
-            BigDecimalField().apply {
-              value = line.discountPercent
-              placeholder = "Remise %"
-              width = "120px"
-              valueChangeMode = ValueChangeMode.EAGER
-              addValueChangeListener {
-                line.discountPercent = it.value ?: BigDecimal.ZERO
-                line.recalculate()
-                refreshGrid()
+    if (showTax) {
+      when (lineTaxMode) {
+        LineTaxMode.DISCOUNT ->
+          grid
+            .addComponentColumn { line ->
+              BigDecimalField().apply {
+                value = line.discountPercent
+                placeholder = "Remise %"
+                width = "120px"
+                valueChangeMode = ValueChangeMode.EAGER
+                addValueChangeListener {
+                  line.discountPercent = it.value ?: BigDecimal.ZERO
+                  line.recalculate()
+                  refreshGrid()
+                }
               }
             }
-          }
-          .setHeader("Remise %")
-          .setAutoWidth(true)
-      LineTaxMode.VAT ->
-        grid
-          .addComponentColumn { line ->
-            BigDecimalField().apply {
-              value = line.vatRate
-              placeholder = "TVA %"
-              width = "120px"
-              valueChangeMode = ValueChangeMode.EAGER
-              addValueChangeListener {
-                line.vatRate = it.value ?: BigDecimal.ZERO
-                line.recalculate()
-                refreshGrid()
+            .setHeader("Remise %")
+            .setAutoWidth(true)
+        LineTaxMode.VAT ->
+          grid
+            .addComponentColumn { line ->
+              BigDecimalField().apply {
+                value = line.vatRate
+                placeholder = "TVA %"
+                width = "120px"
+                valueChangeMode = ValueChangeMode.EAGER
+                addValueChangeListener {
+                  line.vatRate = it.value ?: BigDecimal.ZERO
+                  line.recalculate()
+                  refreshGrid()
+                }
               }
             }
-          }
-          .setHeader("TVA %")
-          .setAutoWidth(true)
+            .setHeader("TVA %")
+            .setAutoWidth(true)
+      }
     }
-    grid.addColumn(DocumentLine::lineTotalExclTax).setHeader("Total HT").setAutoWidth(true)
+    if (showLineTotal) {
+      grid.addColumn(DocumentLine::lineTotalExclTax).setHeader("Total HT").setAutoWidth(true)
+    }
     grid
       .addComponentColumn { line ->
         val deleteBtn =

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
@@ -135,8 +135,9 @@ internal class CommandNetstoneFormDialog(
     if (order?.id != null) {
       val pdfResource =
         StreamResource("${order.orderNumber}.pdf") {
-          pdfService.generateOrderNetstonePdf(order.id!!).inputStream()
-        }
+            pdfService.generateOrderNetstonePdf(order.id!!).inputStream()
+          }
+          .apply { cacheTime = 0 }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink =
         Anchor(pdfResource, "").apply {

--- a/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
+++ b/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
@@ -3,11 +3,14 @@ package fr.axl.lvy.pdf
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.delivery.DeliveryNoteCodigService
 import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
+import fr.axl.lvy.order.OrderCodigService
 import fr.axl.lvy.order.OrderNetstoneService
 import fr.axl.lvy.product.ProductService
+import fr.axl.lvy.sale.SalesCodigService
 import fr.axl.lvy.sale.SalesNetstoneService
 import java.awt.Color
 import java.awt.Font
@@ -28,8 +31,11 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
 /** Generates PDF documents from Thymeleaf templates for business objects. */
 @Service
 class PdfService(
+  private val orderCodigService: OrderCodigService,
   private val orderNetstoneService: OrderNetstoneService,
+  private val deliveryNoteCodigService: DeliveryNoteCodigService,
   private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
+  private val salesCodigService: SalesCodigService,
   private val salesNetstoneService: SalesNetstoneService,
   private val productService: ProductService,
   private val documentLineRepository: DocumentLineRepository,
@@ -144,6 +150,51 @@ class PdfService(
     ctx.setVariable("incotermText", incotermText(order.incoterms, order.incotermLocation))
 
     val html = templateEngine.process("delivery-netstone", ctx)
+
+    val out = ByteArrayOutputStream()
+    PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
+    return out.toByteArray()
+  }
+
+  /**
+   * Generates a PDF for a Codig delivery note. The Codig sale provides the customer reference and
+   * ordered quantities; the delivery note carries delivered quantities and logistics references.
+   */
+  @Transactional(readOnly = true)
+  fun generateDeliveryCodigPdf(noteId: Long): ByteArray {
+    val note =
+      deliveryNoteCodigService.findById(noteId).orElseThrow {
+        IllegalArgumentException("DeliveryNoteCodig $noteId not found")
+      }
+    val order = orderCodigService.findDetailedById(note.orderCodig.id!!).orElse(note.orderCodig)
+    val sale = order.id?.let { salesCodigService.findByOrderCodigId(it).orElse(null) }
+    val deliveryLines =
+      documentLineRepository.findByDocumentTypeAndDocumentIdOrderByPosition(
+        DocumentLine.DocumentType.ORDER_CODIG,
+        order.id!!,
+      )
+    val saleLines = sale?.id?.let { salesCodigService.findLines(it) } ?: emptyList()
+    val ownCompany = clientService.findDefaultCodigCompany().orElse(null)
+    val pcClients = listOf(order.client)
+    val deliveryPdfLines =
+      deliveryLines.map { line -> DeliveryPdfLine.from(line, saleLines, pcClients, productService) }
+
+    val ctx = Context()
+    ctx.setVariable("note", note)
+    ctx.setVariable("order", order)
+    ctx.setVariable("sale", sale)
+    ctx.setVariable("lines", deliveryPdfLines)
+    ctx.setVariable("ownCompany", ownCompany)
+    ctx.setVariable(
+      "ownCompanyAddressLines",
+      ownCompany?.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable("deliveryAddressLines", note.shippingAddress?.lines() ?: emptyList<String>())
+    ctx.setVariable("logoSrc", logoSrc(ownCompany))
+    ctx.setVariable("incotermText", incotermText(order.incoterms, order.incotermLocation))
+    ctx.setVariable("customerReference", sale?.clientReference ?: order.clientReference ?: "")
+
+    val html = templateEngine.process("delivery-codig", ctx)
 
     val out = ByteArrayOutputStream()
     PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()

--- a/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
+++ b/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
@@ -1,12 +1,19 @@
 package fr.axl.lvy.pdf
 
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder
+import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientService
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.order.OrderNetstoneService
+import java.awt.Color
+import java.awt.Font
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.util.Base64
+import java.util.Locale
+import javax.imageio.ImageIO
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.thymeleaf.TemplateEngine
@@ -29,6 +36,7 @@ class PdfService(
           suffix = ".html"
           templateMode = TemplateMode.HTML
           characterEncoding = "UTF-8"
+          isCacheable = false
         }
       )
     }
@@ -49,24 +57,27 @@ class PdfService(
         orderId,
       )
     val ownCompany = clientService.findDefaultCodigSupplier().orElse(null)
+    val supplier = order.supplier
     val currency = order.orderCodig.currency
 
     val ctx = Context()
     ctx.setVariable("order", order)
     ctx.setVariable("lines", lines)
     ctx.setVariable("ownCompany", ownCompany)
+    ctx.setVariable("supplier", supplier)
     ctx.setVariable(
       "ownCompanyAddressLines",
       ownCompany?.billingAddress?.lines() ?: emptyList<String>(),
     )
     ctx.setVariable(
       "supplierAddressLines",
-      order.orderCodig.client.billingAddress?.lines() ?: emptyList<String>(),
+      supplier?.billingAddress?.lines() ?: emptyList<String>(),
     )
     ctx.setVariable("deliveryLocationLines", order.deliveryLocation?.lines() ?: emptyList<String>())
     ctx.setVariable("noteLines", order.notes?.lines() ?: emptyList<String>())
+    ctx.setVariable("supplierNoteLines", supplier?.notes?.lines() ?: emptyList<String>())
     ctx.setVariable("currencySymbol", currencySymbol(currency))
-    ctx.setVariable("logoSrc", logoBase64())
+    ctx.setVariable("logoSrc", logoSrc(ownCompany))
 
     val html = templateEngine.process("order-netstone", ctx)
 
@@ -86,9 +97,46 @@ class PdfService(
     }
 
   /**
-   * Reads the Netstone logo from the classpath and returns a base64 data URI, or null if the file
-   * is not present.
+   * Uses the configured own-company logo first, then falls back to the legacy classpath Netstone
+   * logo when present.
    */
+  private fun logoSrc(ownCompany: Client?): String? =
+    ownCompany?.logoData?.let { normalizeLogoDataUri(it) }
+      ?: logoBase64()
+      ?: generatedLogo(ownCompany?.name ?: "Netstone")
+
+  /**
+   * OpenHTMLToPDF reliably renders PNG/JPEG data URIs. Browser-only formats or incorrect upload
+   * content types are ignored so the PDF does not keep a broken image reference.
+   */
+  private fun normalizeLogoDataUri(logoData: String): String? {
+    val marker = ";base64,"
+    val markerIndex = logoData.indexOf(marker, ignoreCase = true)
+    if (!logoData.startsWith("data:", ignoreCase = true) || markerIndex < 0) return null
+
+    val declaredContentType =
+      logoData.substringAfter("data:").substringBefore(";").lowercase(Locale.ROOT)
+    val base64Data = logoData.substring(markerIndex + marker.length).filterNot { it.isWhitespace() }
+    val bytes =
+      try {
+        Base64.getDecoder().decode(base64Data)
+      } catch (_: IllegalArgumentException) {
+        return null
+      }
+
+    val contentType =
+      when {
+        bytes.isPng() -> "image/png"
+        bytes.isJpeg() -> "image/jpeg"
+        declaredContentType == "image/png" || declaredContentType == "image/jpeg" ->
+          declaredContentType
+        declaredContentType == "image/jpg" -> "image/jpeg"
+        else -> return null
+      }
+    return "data:$contentType;base64," + Base64.getEncoder().encodeToString(bytes)
+  }
+
+  /** Reads the legacy Netstone logo from the classpath and returns a base64 data URI. */
   private fun logoBase64(): String? =
     PdfService::class
       .java
@@ -96,4 +144,42 @@ class PdfService(
       .getResourceAsStream("static/images/logo-netstone.png")
       ?.readBytes()
       ?.let { "data:image/png;base64," + Base64.getEncoder().encodeToString(it) }
+
+  /** Generates a visible PNG wordmark when no uploaded company logo is configured. */
+  private fun generatedLogo(companyName: String): String {
+    val width = 460
+    val height = 170
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val graphics = image.createGraphics()
+    try {
+      graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+      graphics.color = Color(255, 255, 255, 0)
+      graphics.fillRect(0, 0, width, height)
+      graphics.color = Color(224, 112, 40)
+      graphics.fillRect(0, 126, width, 10)
+      graphics.color = Color(51, 51, 51)
+      graphics.font = Font(Font.SANS_SERIF, Font.BOLD, 58)
+      graphics.drawString(companyName.uppercase(Locale.ROOT), 0, 92)
+    } finally {
+      graphics.dispose()
+    }
+
+    val out = ByteArrayOutputStream()
+    ImageIO.write(image, "png", out)
+    return "data:image/png;base64," + Base64.getEncoder().encodeToString(out.toByteArray())
+  }
+
+  private fun ByteArray.isPng(): Boolean =
+    size >= 8 &&
+      this[0] == 0x89.toByte() &&
+      this[1] == 0x50.toByte() &&
+      this[2] == 0x4E.toByte() &&
+      this[3] == 0x47.toByte() &&
+      this[4] == 0x0D.toByte() &&
+      this[5] == 0x0A.toByte() &&
+      this[6] == 0x1A.toByte() &&
+      this[7] == 0x0A.toByte()
+
+  private fun ByteArray.isJpeg(): Boolean =
+    size >= 3 && this[0] == 0xFF.toByte() && this[1] == 0xD8.toByte() && this[2] == 0xFF.toByte()
 }

--- a/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
+++ b/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
@@ -3,14 +3,18 @@ package fr.axl.lvy.pdf
 import com.openhtmltopdf.pdfboxout.PdfRendererBuilder
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.order.OrderNetstoneService
+import fr.axl.lvy.product.ProductService
+import fr.axl.lvy.sale.SalesNetstoneService
 import java.awt.Color
 import java.awt.Font
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
+import java.math.BigDecimal
 import java.util.Base64
 import java.util.Locale
 import javax.imageio.ImageIO
@@ -25,6 +29,9 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver
 @Service
 class PdfService(
   private val orderNetstoneService: OrderNetstoneService,
+  private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
+  private val salesNetstoneService: SalesNetstoneService,
+  private val productService: ProductService,
   private val documentLineRepository: DocumentLineRepository,
   private val clientService: ClientService,
 ) {
@@ -85,6 +92,118 @@ class PdfService(
     PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
     return out.toByteArray()
   }
+
+  /**
+   * Generates a PDF for a Netstone delivery note. The delivery lines provide delivered quantities;
+   * the linked Netstone sale provides the original ordered quantities and delivery address.
+   */
+  @Transactional(readOnly = true)
+  fun generateDeliveryNetstonePdf(noteId: Long): ByteArray {
+    val note =
+      deliveryNoteNetstoneService.findById(noteId).orElseThrow {
+        IllegalArgumentException("DeliveryNoteNetstone $noteId not found")
+      }
+    val order =
+      orderNetstoneService.findDetailedById(note.orderNetstone.id!!).orElse(note.orderNetstone)
+    val sale = order.orderCodig.id?.let { salesNetstoneService.findByOrderCodigId(it).orElse(null) }
+    val deliveryLines = deliveryNoteNetstoneService.findLines(noteId)
+    val saleLines = sale?.id?.let { salesNetstoneService.findLines(it) } ?: emptyList()
+    val ownCompany = clientService.findDefaultCodigSupplier().orElse(null)
+    val codigCompany =
+      clientService
+        .findDefaultCodigCompany()
+        .flatMap { company ->
+          company.id?.let(clientService::findDetailedById) ?: java.util.Optional.of(company)
+        }
+        .orElse(null)
+    val customer = order.orderCodig.client
+    val pcClients = listOfNotNull(codigCompany, customer).distinctBy { it.id }
+    val deliveryPdfLines =
+      deliveryLines.map { line -> DeliveryPdfLine.from(line, saleLines, pcClients, productService) }
+
+    val ctx = Context()
+    ctx.setVariable("note", note)
+    ctx.setVariable("order", order)
+    ctx.setVariable("sale", sale)
+    ctx.setVariable("lines", deliveryPdfLines)
+    ctx.setVariable("ownCompany", ownCompany)
+    ctx.setVariable("codigCompany", codigCompany)
+    ctx.setVariable(
+      "ownCompanyAddressLines",
+      ownCompany?.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable(
+      "deliveryAddressLines",
+      sale?.shippingAddress?.lines() ?: order.deliveryLocation?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable(
+      "codigAddressLines",
+      codigCompany?.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable("logoSrc", logoSrc(ownCompany))
+    ctx.setVariable("incotermText", incotermText(order.incoterms, order.incotermLocation))
+
+    val html = templateEngine.process("delivery-netstone", ctx)
+
+    val out = ByteArrayOutputStream()
+    PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
+    return out.toByteArray()
+  }
+
+  private data class DeliveryPdfLine(
+    val designation: String,
+    val orderedQuantity: BigDecimal,
+    val deliveredQuantity: BigDecimal,
+    val unit: String?,
+    val madeIn: String?,
+    val specifications: String?,
+    val clientProductCode: String?,
+    val hsCode: String?,
+  ) {
+    companion object {
+      fun from(
+        deliveryLine: DocumentLine,
+        saleLines: List<DocumentLine>,
+        pcClients: List<Client>,
+        productService: ProductService,
+      ): DeliveryPdfLine {
+        val saleLine =
+          saleLines.firstOrNull { saleLine ->
+            val deliveryProductId = deliveryLine.product?.id
+            deliveryProductId != null && saleLine.product?.id == deliveryProductId
+          } ?: saleLines.firstOrNull { it.designation == deliveryLine.designation }
+        val product =
+          (deliveryLine.product ?: saleLine?.product)?.id?.let {
+            productService.findDetailedById(it).orElse(null)
+          } ?: deliveryLine.product ?: saleLine?.product
+        val productId = product?.id ?: deliveryLine.product?.id ?: saleLine?.product?.id
+        return DeliveryPdfLine(
+          designation = deliveryLine.designation,
+          orderedQuantity = saleLine?.quantity ?: deliveryLine.quantity,
+          deliveredQuantity = deliveryLine.quantity,
+          unit = deliveryLine.unit ?: saleLine?.unit,
+          madeIn = deliveryLine.madeIn ?: saleLine?.madeIn ?: product?.madeIn,
+          specifications =
+            product?.specifications ?: deliveryLine.description ?: saleLine?.description,
+          clientProductCode =
+            productId?.let { currentClientProductCode(it, pcClients, productService) },
+          hsCode = deliveryLine.hsCode ?: saleLine?.hsCode ?: product?.hsCode,
+        )
+      }
+
+      private fun currentClientProductCode(
+        productId: Long,
+        pcClients: List<Client>,
+        productService: ProductService,
+      ): String? =
+        pcClients.firstNotNullOfOrNull { client ->
+          client.id?.let { productService.findClientProductCode(productId, it) }
+        } ?: productService.findFirstClientProductCode(productId)
+    }
+  }
+
+  private fun incotermText(incoterm: String?, location: String?): String =
+    listOfNotNull(incoterm, location?.takeIf { it.isNotBlank() }).joinToString(" ")
 
   private fun currencySymbol(currency: String): String =
     when (currency.uppercase()) {

--- a/src/main/kotlin/fr/axl/lvy/product/Product.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/Product.kt
@@ -68,10 +68,29 @@ class Product(
 
   /** Replaces all client-specific product codes with the given entries. */
   fun replaceClientProductCodes(entries: List<Pair<Client, String>>) {
-    clientProductCodes.clear()
-    entries.forEach { (client, code) ->
-      val clientProductCode = ProductClientCode(this, client, code)
-      clientProductCodes.add(clientProductCode)
+    val entriesByClientId =
+      entries
+        .filter { (client, code) -> client.id != null && code.isNotBlank() }
+        .associateBy({ (client, _) -> client.id!! }, { it })
+
+    val iterator = clientProductCodes.iterator()
+    while (iterator.hasNext()) {
+      val current = iterator.next()
+      val desired = current.client.id?.let(entriesByClientId::get)
+      if (desired == null) {
+        iterator.remove()
+      } else {
+        current.client = desired.first
+        current.code = desired.second
+      }
+    }
+
+    val existingClientIds = clientProductCodes.mapNotNull { it.client.id }.toSet()
+    entriesByClientId.forEach { (clientId, entry) ->
+      if (clientId !in existingClientIds) {
+        val clientProductCode = ProductClientCode(this, entry.first, entry.second)
+        clientProductCodes.add(clientProductCode)
+      }
     }
   }
 

--- a/src/main/kotlin/fr/axl/lvy/product/Product.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/Product.kt
@@ -68,10 +68,12 @@ class Product(
 
   /** Replaces all client-specific product codes with the given entries. */
   fun replaceClientProductCodes(entries: List<Pair<Client, String>>) {
+    val validEntries = entries.filter { (_, code) -> code.isNotBlank() }
     val entriesByClientId =
-      entries
-        .filter { (client, code) -> client.id != null && code.isNotBlank() }
+      validEntries
+        .filter { (client, _) -> client.id != null }
         .associateBy({ (client, _) -> client.id!! }, { it })
+    val transientEntries = validEntries.filter { (client, _) -> client.id == null }
 
     val iterator = clientProductCodes.iterator()
     while (iterator.hasNext()) {
@@ -88,9 +90,11 @@ class Product(
     val existingClientIds = clientProductCodes.mapNotNull { it.client.id }.toSet()
     entriesByClientId.forEach { (clientId, entry) ->
       if (clientId !in existingClientIds) {
-        val clientProductCode = ProductClientCode(this, entry.first, entry.second)
-        clientProductCodes.add(clientProductCode)
+        clientProductCodes.add(ProductClientCode(this, entry.first, entry.second))
       }
+    }
+    transientEntries.forEach { (client, code) ->
+      clientProductCodes.add(ProductClientCode(this, client, code))
     }
   }
 

--- a/src/main/kotlin/fr/axl/lvy/product/ProductClientCodeRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductClientCodeRepository.kt
@@ -1,0 +1,27 @@
+package fr.axl.lvy.product
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface ProductClientCodeRepository : JpaRepository<ProductClientCode, Long> {
+
+  @Query(
+    """
+      SELECT pcc.code
+      FROM ProductClientCode pcc
+      WHERE pcc.product.id = :productId
+        AND pcc.client.id = :clientId
+    """
+  )
+  fun findCodeByProductIdAndClientId(productId: Long, clientId: Long): String?
+
+  @Query(
+    """
+      SELECT pcc.code
+      FROM ProductClientCode pcc
+      WHERE pcc.product.id = :productId
+      ORDER BY pcc.id
+    """
+  )
+  fun findCodesByProductId(productId: Long): List<String>
+}

--- a/src/main/kotlin/fr/axl/lvy/product/ProductService.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductService.kt
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class ProductService(
   private val productRepository: ProductRepository,
+  private val productClientCodeRepository: ProductClientCodeRepository,
   private val clientRepository: ClientRepository,
 ) {
 
@@ -26,6 +27,14 @@ class ProductService(
   @Transactional(readOnly = true)
   fun findDetailedById(id: Long): Optional<Product> =
     Optional.ofNullable(productRepository.findDetailedById(id))
+
+  @Transactional(readOnly = true)
+  fun findClientProductCode(productId: Long, clientId: Long): String? =
+    productClientCodeRepository.findCodeByProductIdAndClientId(productId, clientId)
+
+  @Transactional(readOnly = true)
+  fun findFirstClientProductCode(productId: Long): String? =
+    productClientCodeRepository.findCodesByProductId(productId).firstOrNull()
 
   @Transactional
   fun save(product: Product): Product {

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesCodigRepository.kt
@@ -36,5 +36,15 @@ interface SalesCodigRepository : JpaRepository<SalesCodig, Long> {
   )
   fun findDetailedById(id: Long): SalesCodig?
 
+  @Query(
+    """
+      SELECT s
+      FROM SalesCodig s
+      LEFT JOIN FETCH s.client
+      LEFT JOIN FETCH s.orderCodig o
+      WHERE o.id = :orderCodigId
+        AND s.deletedAt IS NULL
+    """
+  )
   fun findByOrderCodigId(orderCodigId: Long): SalesCodig?
 }

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
@@ -16,6 +16,7 @@ import fr.axl.lvy.base.ui.ViewToolbar
 import fr.axl.lvy.base.ui.initAsListContainer
 import fr.axl.lvy.client.ClientService
 import fr.axl.lvy.delivery.DeliveryNoteCodigService
+import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.delivery.ui.DeliveryNoteCodigFormDialog
 import fr.axl.lvy.fiscalposition.FiscalPositionService
 import fr.axl.lvy.incoterm.IncotermService
@@ -43,6 +44,7 @@ internal class SalesCodigListView(
   private val fiscalPositionService: FiscalPositionService,
   private val productService: ProductService,
   private val deliveryNoteCodigService: DeliveryNoteCodigService,
+  private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
   private val orderCodigService: OrderCodigService,
   private val salesNetstoneService: SalesNetstoneService,
   private val orderNetstoneService: OrderNetstoneService,
@@ -260,9 +262,20 @@ internal class SalesCodigListView(
 
     val deliveryNote =
       orderCodig.deliveryNote ?: deliveryNoteCodigService.findByOrderCodigId(orderCodig.id!!)
+    val netstoneDeliveryNote =
+      salesNetstoneService
+        .findByOrderCodigId(orderCodig.id!!)
+        .orElse(null)
+        ?.orderNetstone
+        ?.id
+        ?.let(deliveryNoteNetstoneService::findByOrderNetstoneId)
     DeliveryNoteCodigFormDialog(
         deliveryNoteCodigService,
+        pdfService,
         orderCodig,
+        loadedSale.saleNumber,
+        loadedSale.clientReference,
+        netstoneDeliveryNote,
         deliveryNote,
         this::refreshGrid,
       )

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneListView.kt
@@ -4,6 +4,9 @@ import com.vaadin.flow.component.button.Button
 import com.vaadin.flow.component.button.ButtonVariant
 import com.vaadin.flow.component.grid.Grid
 import com.vaadin.flow.component.grid.GridVariant
+import com.vaadin.flow.component.notification.Notification
+import com.vaadin.flow.component.notification.NotificationVariant
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.router.Menu
 import com.vaadin.flow.router.PageTitle
@@ -11,6 +14,8 @@ import com.vaadin.flow.router.Route
 import fr.axl.lvy.base.ui.ViewToolbar
 import fr.axl.lvy.base.ui.initAsListContainer
 import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
+import fr.axl.lvy.delivery.ui.DeliveryNoteNetstoneFormDialog
 import fr.axl.lvy.fiscalposition.FiscalPositionService
 import fr.axl.lvy.incoterm.IncotermService
 import fr.axl.lvy.order.OrderCodigService
@@ -31,6 +36,7 @@ import fr.axl.lvy.sale.SalesNetstoneService
 internal class SalesNetstoneListView(
   private val salesNetstoneService: SalesNetstoneService,
   private val orderNetstoneService: OrderNetstoneService,
+  private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
   private val clientService: ClientService,
   private val salesCodigService: SalesCodigService,
   private val incotermService: IncotermService,
@@ -64,6 +70,20 @@ internal class SalesNetstoneListView(
     grid.addColumn(SalesNetstone::totalExclTax).setHeader("Total HT").setAutoWidth(true)
     grid.addColumn(SalesNetstone::totalInclTax).setHeader("Total TTC").setAutoWidth(true)
     grid.addColumn { it.status.name }.setHeader("Statut").setAutoWidth(true)
+    grid
+      .addComponentColumn { sale ->
+        val viewButton = Button("Ouvrir") { openForm(sale) }
+        viewButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY)
+        val deliveryButton = Button("Livraison") { openDeliveryForm(sale) }
+        deliveryButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
+        deliveryButton.isEnabled = sale.orderNetstone != null
+        HorizontalLayout(viewButton, deliveryButton).apply {
+          isPadding = false
+          isSpacing = true
+        }
+      }
+      .setHeader("Actions")
+      .setAutoWidth(true)
     grid.setEmptyStateText("Aucune vente Netstone")
     grid.setSizeFull()
     grid.addThemeVariants(GridVariant.LUMO_NO_BORDER)
@@ -198,6 +218,39 @@ internal class SalesNetstoneListView(
     val linkedSale =
       order.id?.let { salesNetstoneService.findByOrderCodigId(it).orElse(null) } ?: return
     openForm(linkedSale)
+  }
+
+  private fun openDeliveryForm(sale: SalesNetstone) {
+    val loadedSale = sale.id?.let { salesNetstoneService.findDetailedById(it).orElse(sale) } ?: sale
+    val linkedOrder = loadedSale.orderNetstone
+    if (linkedOrder?.id == null) {
+      Notification.show(
+          "Générez d'abord la commande Netstone liée",
+          4000,
+          Notification.Position.BOTTOM_END,
+        )
+        .addThemeVariants(NotificationVariant.LUMO_ERROR)
+      return
+    }
+    val orderNetstone = orderNetstoneService.findDetailedById(linkedOrder.id!!).orElse(linkedOrder)
+    val deliveryNote = deliveryNoteNetstoneService.findByOrderNetstoneId(orderNetstone.id!!)
+    val initialLines =
+      deliveryNote?.id?.let { deliveryNoteNetstoneService.findLines(it) }
+        ?: loadedSale.id?.let { salesNetstoneService.findLines(it) }
+        ?: emptyList()
+
+    DeliveryNoteNetstoneFormDialog(
+        deliveryNoteNetstoneService,
+        productService,
+        pdfService,
+        orderNetstone,
+        loadedSale.saleNumber,
+        loadedSale.shippingAddress,
+        deliveryNote,
+        initialLines,
+        this::refreshGrid,
+      )
+      .open()
   }
 
   private fun refreshGrid() {

--- a/src/main/resources/templates/pdf/delivery-codig.html
+++ b/src/main/resources/templates/pdf/delivery-codig.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 11pt;
+      color: #333333;
+      margin: 0;
+      padding: 0;
+    }
+
+    p { margin: 0; padding: 0; }
+
+    .header-table { width: 100%; margin-bottom: 28pt; }
+    .logo-cell { width: 58%; vertical-align: top; }
+    .logo-cell img { height: 80pt; max-width: 180pt; }
+    .addr-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .company-name { font-size: 12pt; font-weight: bold; margin-bottom: 4pt; }
+
+    .parties-table { width: 100%; margin-bottom: 24pt; }
+    .delivery-cell { width: 58%; vertical-align: top; font-size: 10pt; }
+    .block-label { font-weight: bold; margin-bottom: 4pt; }
+
+    .document-title {
+      color: #E07028;
+      font-size: 24pt;
+      font-weight: bold;
+      margin-bottom: 16pt;
+    }
+
+    .meta-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 20pt;
+    }
+    .meta-table th {
+      color: #E07028;
+      font-size: 9pt;
+      font-weight: bold;
+      text-align: left;
+      padding: 0 8pt 3pt 0;
+    }
+    .meta-table td {
+      font-size: 10pt;
+      padding: 0 8pt 0 0;
+      vertical-align: top;
+    }
+
+    .lines-table {
+      width: 100%;
+      border-collapse: collapse;
+      border-top: 3pt double #333333;
+      border-bottom: 3pt double #333333;
+      margin-bottom: 16pt;
+    }
+    .lines-table th {
+      padding: 7pt 8pt;
+      font-size: 9pt;
+      font-weight: bold;
+      text-align: left;
+    }
+    .lines-table th.right { text-align: right; }
+    .lines-table td {
+      padding: 7pt 8pt;
+      font-size: 10pt;
+      vertical-align: top;
+    }
+    .lines-table td.right { text-align: right; }
+
+    .details-block {
+      margin-top: 10pt;
+      font-size: 10pt;
+      line-height: 1.35;
+    }
+    .detail-line { margin-bottom: 4pt; }
+
+    @page {
+      margin: 18mm 18mm 22mm 18mm;
+      @bottom-right {
+        content: counter(page);
+        font-size: 9pt;
+        color: #777777;
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <table class="header-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="logo-cell">
+        <img th:if="${logoSrc != null}" th:src="${logoSrc}" alt=""/>
+      </td>
+      <td class="addr-cell" th:if="${ownCompany != null}">
+        <p class="company-name" th:text="${ownCompany.name}"></p>
+        <p th:each="line : ${ownCompanyAddressLines}" th:text="${line}"></p>
+        <p th:if="${ownCompany.vatNumber != null}" th:text="${'TVA: ' + ownCompany.vatNumber}"></p>
+      </td>
+    </tr>
+  </table>
+
+  <table class="parties-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="delivery-cell">
+        <p class="block-label">DELIVERY ADDRESS:</p>
+        <p th:each="line : ${deliveryAddressLines}" th:text="${line}"></p>
+      </td>
+    </tr>
+  </table>
+
+  <p class="document-title" th:text="'Delivery Note #' + ${note.deliveryNoteNumber}"></p>
+
+  <table class="meta-table">
+    <thead>
+      <tr>
+        <th style="width: 25%;">Order :</th>
+        <th style="width: 25%;">Arrival date :</th>
+        <th style="width: 25%;">Custommer ref. :</th>
+        <th style="width: 25%;">Incoterm :</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td th:text="${sale != null ? sale.saleNumber : ''}"></td>
+        <td th:text="${note.arrivalDate != null ? #temporals.format(note.arrivalDate, 'dd/MM/yyyy') : ''}"></td>
+        <td th:text="${customerReference}"></td>
+        <td th:text="${incotermText}"></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <table class="lines-table">
+    <thead>
+      <tr>
+        <th style="width: 50%;">PRODUCT</th>
+        <th class="right" style="width: 25%;">ORDERED</th>
+        <th class="right" style="width: 25%;">DELIVERED</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr th:each="line : ${lines}">
+        <td th:text="${line.designation}"></td>
+        <td class="right"
+            th:text="${#numbers.formatDecimal(line.orderedQuantity, 1, 'WHITESPACE', 2, 'COMMA')
+                       + (line.unit != null ? ' ' + line.unit : '')}"></td>
+        <td class="right"
+            th:text="${#numbers.formatDecimal(line.deliveredQuantity, 1, 'WHITESPACE', 2, 'COMMA')
+                       + (line.unit != null ? ' ' + line.unit : '')}"></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="details-block" th:each="line : ${lines}">
+    <p class="detail-line"
+       th:text="${'PO : ' + customerReference
+                 + (incotermText != '' ? ' / ' + incotermText : '')
+                 + (line.madeIn != null ? ' / Made in : ' + line.madeIn : '')}"></p>
+    <p class="detail-line" th:if="${line.specifications != null}" th:text="${line.specifications}"></p>
+    <p class="detail-line" th:if="${line.clientProductCode != null}" th:text="${'PC: ' + line.clientProductCode}"></p>
+    <p class="detail-line" th:if="${line.hsCode != null}" th:text="'HS CODE : ' + ${line.hsCode}"></p>
+  </div>
+
+  <div class="details-block">
+    <p class="detail-line"
+       th:text="${'BL : ' + (note.billOfLading != null ? note.billOfLading : '')
+                 + (note.containerNumber != null ? ' / ' + note.containerNumber : '')
+                 + (note.seals != null ? ' / SEALS : ' + note.seals : '')
+                 + (note.lot != null ? ' / LOT : ' + note.lot : '')}"></p>
+  </div>
+
+</body>
+</html>

--- a/src/main/resources/templates/pdf/delivery-netstone.html
+++ b/src/main/resources/templates/pdf/delivery-netstone.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 11pt;
+      color: #333333;
+      margin: 0;
+      padding: 0;
+    }
+
+    p { margin: 0; padding: 0; }
+
+    .header-table { width: 100%; margin-bottom: 28pt; }
+    .logo-cell { width: 58%; vertical-align: top; }
+    .logo-cell img { height: 80pt; max-width: 180pt; }
+    .addr-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .company-name { font-size: 12pt; font-weight: bold; margin-bottom: 4pt; }
+
+    .parties-table { width: 100%; margin-bottom: 24pt; }
+    .delivery-cell { width: 58%; vertical-align: top; font-size: 10pt; }
+    .customer-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .block-label { font-weight: bold; margin-bottom: 4pt; }
+
+    .document-title {
+      color: #E07028;
+      font-size: 24pt;
+      font-weight: bold;
+      margin-bottom: 16pt;
+    }
+
+    .meta-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 20pt;
+    }
+    .meta-table th {
+      color: #E07028;
+      font-size: 9pt;
+      font-weight: bold;
+      text-align: left;
+      padding: 0 8pt 3pt 0;
+    }
+    .meta-table td {
+      font-size: 10pt;
+      padding: 0 8pt 0 0;
+      vertical-align: top;
+    }
+
+    .lines-table {
+      width: 100%;
+      border-collapse: collapse;
+      border-top: 3pt double #333333;
+      border-bottom: 3pt double #333333;
+      margin-bottom: 16pt;
+    }
+    .lines-table th {
+      padding: 7pt 8pt;
+      font-size: 9pt;
+      font-weight: bold;
+      text-align: left;
+    }
+    .lines-table th.right { text-align: right; }
+    .lines-table td {
+      padding: 7pt 8pt;
+      font-size: 10pt;
+      vertical-align: top;
+    }
+    .lines-table td.right { text-align: right; }
+
+    .details-block {
+      margin-top: 10pt;
+      font-size: 10pt;
+      line-height: 1.35;
+    }
+    .detail-line { margin-bottom: 4pt; }
+
+    @page {
+      margin: 18mm 18mm 22mm 18mm;
+      @bottom-right {
+        content: counter(page);
+        font-size: 9pt;
+        color: #777777;
+      }
+    }
+  </style>
+</head>
+<body>
+
+  <table class="header-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="logo-cell">
+        <img th:if="${logoSrc != null}" th:src="${logoSrc}" alt=""/>
+      </td>
+      <td class="addr-cell" th:if="${ownCompany != null}">
+        <p class="company-name" th:text="${ownCompany.name}"></p>
+        <p th:each="line : ${ownCompanyAddressLines}" th:text="${line}"></p>
+      </td>
+    </tr>
+  </table>
+
+  <table class="parties-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="delivery-cell">
+        <p class="block-label">DELIVERY ADDRESS:</p>
+        <p th:each="line : ${deliveryAddressLines}" th:text="${line}"></p>
+      </td>
+      <td class="customer-cell" th:if="${codigCompany != null}">
+        <p class="block-label">CUSTOMER ADDRESS:</p>
+        <p class="company-name" th:text="${codigCompany.name}"></p>
+        <p th:each="line : ${codigAddressLines}" th:text="${line}"></p>
+        <p th:if="${codigCompany.vatNumber != null}"
+           th:text="${'TVA: ' + codigCompany.vatNumber}"></p>
+      </td>
+    </tr>
+  </table>
+
+  <p class="document-title" th:text="'Delivery Note #' + ${note.deliveryNoteNumber}"></p>
+
+  <table class="meta-table">
+    <thead>
+      <tr>
+        <th style="width: 25%;">Order :</th>
+        <th style="width: 25%;">Arrival date :</th>
+        <th style="width: 25%;">Custommer ref. :</th>
+        <th style="width: 25%;">Incoterm :</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td th:text="${sale != null ? sale.saleNumber : ''}"></td>
+        <td th:text="${note.arrivalDate != null ? #temporals.format(note.arrivalDate, 'dd/MM/yyyy') : ''}"></td>
+        <td th:text="${order.orderCodig.orderNumber}"></td>
+        <td th:text="${incotermText}"></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <table class="lines-table">
+    <thead>
+      <tr>
+        <th style="width: 50%;">PRODUCT</th>
+        <th class="right" style="width: 25%;">ORDERED</th>
+        <th class="right" style="width: 25%;">DELIVERED</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr th:each="line : ${lines}">
+        <td th:text="${line.designation}"></td>
+        <td class="right"
+            th:text="${#numbers.formatDecimal(line.orderedQuantity, 1, 'WHITESPACE', 2, 'COMMA')
+                       + (line.unit != null ? ' ' + line.unit : '')}"></td>
+        <td class="right"
+            th:text="${#numbers.formatDecimal(line.deliveredQuantity, 1, 'WHITESPACE', 2, 'COMMA')
+                       + (line.unit != null ? ' ' + line.unit : '')}"></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="details-block" th:each="line : ${lines}">
+    <p class="detail-line"
+       th:text="${'PO : ' + order.orderCodig.orderNumber
+                 + (incotermText != '' ? ' / ' + incotermText : '')
+                 + (line.madeIn != null ? ' / Made in : ' + line.madeIn : '')}"></p>
+    <p class="detail-line" th:if="${line.specifications != null}" th:text="${line.specifications}"></p>
+    <p class="detail-line" th:if="${line.clientProductCode != null}" th:text="${'PC: ' + line.clientProductCode}"></p>
+    <p class="detail-line" th:if="${line.hsCode != null}" th:text="'HS CODE : ' + ${line.hsCode}"></p>
+  </div>
+
+  <div class="details-block">
+    <p class="detail-line"
+       th:text="${'BL : ' + (note.billOfLading != null ? note.billOfLading : '')
+                 + (note.containerNumber != null ? ' / ' + note.containerNumber : '')
+                 + (note.seals != null ? ' / SEALS : ' + note.seals : '')
+                 + (note.lot != null ? ' / LOT : ' + note.lot : '')}"></p>
+  </div>
+
+</body>
+</html>

--- a/src/main/resources/templates/pdf/order-netstone.html
+++ b/src/main/resources/templates/pdf/order-netstone.html
@@ -15,15 +15,15 @@
 
     /* ── Header ── */
     .header-table { width: 100%; margin-bottom: 32pt; }
-    .logo-cell    { width: 45%; vertical-align: top; }
-    .logo-cell img { height: 80pt; }
-    .addr-cell    { width: 55%; vertical-align: top; font-size: 10pt; }
+    .logo-cell    { width: 58%; vertical-align: top; }
+    .logo-cell img { height: 80pt; max-width: 180pt; }
+    .addr-cell    { width: 42%; vertical-align: top; font-size: 10pt; }
     .addr-cell .company-name { font-size: 12pt; font-weight: bold; margin-bottom: 4pt; }
 
     /* ── Delivery / supplier block ── */
     .parties-table { width: 100%; margin-bottom: 24pt; }
-    .delivery-cell { width: 45%; vertical-align: top; }
-    .supplier-cell { width: 55%; vertical-align: top; font-size: 10pt; }
+    .delivery-cell { width: 58%; vertical-align: top; }
+    .supplier-cell { width: 42%; vertical-align: top; font-size: 10pt; }
     .supplier-cell .supplier-name { font-size: 11pt; font-weight: bold; margin-bottom: 4pt; }
 
     /* ── Order title ── */
@@ -37,8 +37,14 @@
 
     /* ── Line items ── */
     .lines-table { width: 100%; border-collapse: collapse; margin-bottom: 12pt; }
-    .lines-table thead tr {
+    .lines-table thead .double-rule th {
       border-top: 2pt solid #333333;
+      border-bottom: 1pt solid #333333;
+      height: 3pt;
+      line-height: 3pt;
+      padding: 0;
+    }
+    .lines-table thead tr {
       border-bottom: 2pt solid #333333;
     }
     .lines-table thead th {
@@ -53,8 +59,8 @@
     .lines-table tbody td.right { text-align: right; }
 
     /* ── Totals ── */
-    .totals-table { width: 320pt; border-collapse: collapse; }
-    .totals-table td { padding: 4pt 8pt; font-size: 10pt; }
+    .totals-table { width: 230pt; border-collapse: collapse; }
+    .totals-table td { padding: 4pt 4pt; font-size: 10pt; }
     .totals-table .amount { text-align: right; }
     .totals-table .final-row td {
       color: #E07028;
@@ -98,13 +104,11 @@
   <table class="parties-table" cellspacing="0" cellpadding="0">
     <tr>
       <td class="delivery-cell">
-        <p><strong>Delivery Address:</strong></p>
-        <p th:if="${order.incoterms != null}"
-           th:text="'Port of: ' + (order.incotermLocation != null ? order.incotermLocation : '')"></p>
+        <p><strong>DELIVERY ADDRESS:</strong></p>
         <p th:each="line : ${deliveryLocationLines}" th:text="${line}"></p>
       </td>
-      <td class="supplier-cell">
-        <p class="supplier-name" th:text="${order.orderCodig.client.name}"></p>
+      <td class="supplier-cell" th:if="${supplier != null}">
+        <p class="supplier-name" th:text="${supplier.name}"></p>
         <p th:each="line : ${supplierAddressLines}" th:text="${line}"></p>
       </td>
     </tr>
@@ -133,21 +137,21 @@
   <!-- ═══════════ LINE ITEMS ═══════════ -->
   <table class="lines-table">
     <thead>
+      <tr class="double-rule">
+        <th colspan="6"></th>
+      </tr>
       <tr>
         <th style="width: 34%;">DESCRIPTION</th>
-        <th style="width: 8%;">TAXES</th>
         <th style="width: 16%;">DATE REQ.</th>
         <th class="right" style="width: 16%;">QTY</th>
         <th class="right" style="width: 13%;">UNIT PRICE</th>
+        <th style="width: 8%;">TAXES</th>
         <th class="right" style="width: 13%;">AMOUNT</th>
       </tr>
     </thead>
     <tbody>
       <tr th:each="line : ${lines}">
         <td th:text="${line.designation}"></td>
-        <td th:text="${line.vatRate.signum() != 0
-                       ? #numbers.formatDecimal(line.vatRate, 1, 'NONE', 0, 'COMMA') + '%'
-                       : ''}"></td>
         <td th:text="${order.expectedDeliveryDate != null
                        ? #temporals.format(order.expectedDeliveryDate, 'dd/MM/yyyy')
                        : ''}"></td>
@@ -156,6 +160,9 @@
                        + (line.unit != null ? ' ' + line.unit : '')}"></td>
         <td class="right"
             th:text="${#numbers.formatDecimal(line.unitPriceExclTax, 1, 'NONE', 2, 'COMMA')}"></td>
+        <td th:text="${line.vatRate.signum() != 0
+                       ? #numbers.formatDecimal(line.vatRate, 1, 'NONE', 0, 'COMMA') + '%'
+                       : ''}"></td>
         <td class="right"
             th:text="${currencySymbol + ' ' + #numbers.formatDecimal(line.lineTotalExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td>
       </tr>
@@ -184,6 +191,10 @@
        th:text="${order.fiscalPosition.position}"></p>
     <div th:if="${not #lists.isEmpty(noteLines)}" style="margin-top: 10pt;">
       <p th:each="noteLine : ${noteLines}" class="note-line" th:text="${noteLine}"></p>
+    </div>
+    <div th:if="${not #lists.isEmpty(supplierNoteLines)}" style="margin-top: 10pt;">
+      <p th:each="supplierNoteLine, iter : ${supplierNoteLines}" class="note-line"
+         th:text="${supplierNoteLine + (iter.last and order.incoterms != null and #strings.equalsIgnoreCase(order.incoterms, 'CIF') ? ' AND INSURANCE' : '')}"></p>
     </div>
   </div>
 

--- a/src/test/kotlin/fr/axl/lvy/base/DocumentLineSchemaUpdaterTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/base/DocumentLineSchemaUpdaterTest.kt
@@ -1,0 +1,109 @@
+package fr.axl.lvy.base
+
+import java.sql.Connection
+import java.sql.DatabaseMetaData
+import javax.sql.DataSource
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.springframework.boot.ApplicationArguments
+import org.springframework.jdbc.core.JdbcTemplate
+
+/**
+ * Unit tests for [DocumentLineSchemaUpdater]. Uses mocked [JdbcTemplate] so the MySQL-only branch
+ * is reachable from the H2 test runtime.
+ */
+class DocumentLineSchemaUpdaterTest {
+
+  @Test
+  fun run_skips_when_database_is_not_mysql() {
+    val jdbc = mockJdbcWithProductName("H2")
+
+    DocumentLineSchemaUpdater(jdbc).run(mock(ApplicationArguments::class.java))
+
+    verify(jdbc, never()).execute(anyString())
+    verify(jdbc, never()).queryForList(anyString(), eq(String::class.java))
+  }
+
+  @Test
+  fun run_skips_when_datasource_metadata_throws() {
+    val jdbc = mock(JdbcTemplate::class.java)
+    val dataSource = mock(DataSource::class.java)
+    `when`(jdbc.dataSource).thenReturn(dataSource)
+    `when`(dataSource.connection).thenThrow(RuntimeException("boom"))
+
+    DocumentLineSchemaUpdater(jdbc).run(mock(ApplicationArguments::class.java))
+
+    verify(jdbc, never()).execute(anyString())
+  }
+
+  @Test
+  fun run_drops_existing_constraint_and_adds_expected_check_for_mysql() {
+    val jdbc = mockJdbcWithProductName("MySQL")
+    @Suppress("UNCHECKED_CAST")
+    `when`(jdbc.queryForList(anyString(), eq(String::class.java)))
+      .thenReturn(listOf("document_lines_chk_1"))
+
+    DocumentLineSchemaUpdater(jdbc).run(mock(ApplicationArguments::class.java))
+
+    val sqlCaptor = ArgumentCaptor.forClass(String::class.java)
+    verify(jdbc, times(2)).execute(sqlCaptor.capture())
+    val executed = sqlCaptor.allValues
+    assertThat(executed[0])
+      .contains("ALTER TABLE document_lines DROP CHECK")
+      .contains("document_lines_chk_1")
+    assertThat(executed[1])
+      .contains("ADD CONSTRAINT document_lines_document_type_chk")
+      .contains("'SALES_CODIG'")
+      .contains("'DELIVERY_NETSTONE'")
+      .contains("'INVOICE_NETSTONE'")
+  }
+
+  @Test
+  fun run_adds_constraint_even_when_no_existing_check() {
+    val jdbc = mockJdbcWithProductName("MySQL")
+    @Suppress("UNCHECKED_CAST")
+    `when`(jdbc.queryForList(anyString(), eq(String::class.java))).thenReturn(emptyList())
+
+    DocumentLineSchemaUpdater(jdbc).run(mock(ApplicationArguments::class.java))
+
+    val sqlCaptor = ArgumentCaptor.forClass(String::class.java)
+    verify(jdbc, times(1)).execute(sqlCaptor.capture())
+    assertThat(sqlCaptor.value).contains("ADD CONSTRAINT document_lines_document_type_chk")
+  }
+
+  @Test
+  fun run_drops_each_existing_constraint() {
+    val jdbc = mockJdbcWithProductName("MySQL")
+    @Suppress("UNCHECKED_CAST")
+    `when`(jdbc.queryForList(anyString(), eq(String::class.java))).thenReturn(listOf("c1", "c2"))
+
+    DocumentLineSchemaUpdater(jdbc).run(mock(ApplicationArguments::class.java))
+
+    val sqlCaptor = ArgumentCaptor.forClass(String::class.java)
+    verify(jdbc, times(3)).execute(sqlCaptor.capture())
+    val statements = sqlCaptor.allValues
+    assertThat(statements[0]).contains("DROP CHECK `c1`")
+    assertThat(statements[1]).contains("DROP CHECK `c2`")
+    assertThat(statements[2]).contains("ADD CONSTRAINT")
+  }
+
+  private fun mockJdbcWithProductName(productName: String): JdbcTemplate {
+    val jdbc = mock(JdbcTemplate::class.java)
+    val dataSource = mock(DataSource::class.java)
+    val connection = mock(Connection::class.java)
+    val metaData = mock(DatabaseMetaData::class.java)
+    `when`(jdbc.dataSource).thenReturn(dataSource)
+    `when`(dataSource.connection).thenReturn(connection)
+    `when`(connection.metaData).thenReturn(metaData)
+    `when`(metaData.databaseProductName).thenReturn(productName)
+    return jdbc
+  }
+}

--- a/src/test/kotlin/fr/axl/lvy/base/NumberSequenceServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/base/NumberSequenceServiceTest.kt
@@ -56,4 +56,32 @@ class NumberSequenceServiceTest {
     val orderCodig = numberSequenceService.nextNumber(NumberSequenceService.ORDER_CODIG)
     assertThat(orderCodig).isEqualTo("CoD_PO_001")
   }
+
+  @Test
+  fun nextNumber_throws_for_unknown_entity_type() {
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+        numberSequenceService.nextNumber("NO_SUCH_TYPE")
+      }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  @Test
+  fun previewNextNumber_returns_next_without_advancing_sequence() {
+    val preview = numberSequenceService.previewNextNumber(NumberSequenceService.DELIVERY_NETSTONE)
+    val next = numberSequenceService.nextNumber(NumberSequenceService.DELIVERY_NETSTONE)
+    val secondPreview =
+      numberSequenceService.previewNextNumber(NumberSequenceService.DELIVERY_NETSTONE)
+
+    assertThat(preview).isEqualTo("Netst/OUT/001")
+    assertThat(next).isEqualTo(preview)
+    assertThat(secondPreview).isEqualTo("Netst/OUT/002")
+  }
+
+  @Test
+  fun previewNextNumber_throws_for_unknown_entity_type() {
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+        numberSequenceService.previewNextNumber("NO_SUCH_TYPE")
+      }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
 }

--- a/src/test/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodigServiceTest.kt
@@ -34,7 +34,7 @@ class DeliveryNoteCodigServiceTest {
     val note = DeliveryNoteCodig("", order, client)
     val saved = deliveryNoteCodigService.save(note)
 
-    assertThat(saved.deliveryNoteNumber).startsWith("BL-")
+    assertThat(saved.deliveryNoteNumber).startsWith("CoD/OUT/")
     assertThat(saved.id).isNotNull
     val reloadedOrder = orderCodigRepository.findById(order.id!!).orElseThrow()
     assertThat(reloadedOrder.deliveryNote!!.id).isEqualTo(saved.id)

--- a/src/test/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodigTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodigTest.kt
@@ -32,6 +32,10 @@ class DeliveryNoteCodigTest {
     val note = DeliveryNoteCodig("BL-2026-0001", order, client)
     note.carrier = "DHL"
     note.trackingNumber = "TRACK-001"
+    note.billOfLading = "BL-OCEAN-001"
+    note.containerNumber = "CONT-001"
+    note.lot = "LOT-A"
+    note.seals = "SEAL-123"
     deliveryNoteCodigRepository.save(note)
 
     val found = deliveryNoteCodigRepository.findById(note.id!!)
@@ -39,6 +43,10 @@ class DeliveryNoteCodigTest {
     assertThat(found.get().deliveryNoteNumber).isEqualTo("BL-2026-0001")
     assertThat(found.get().carrier).isEqualTo("DHL")
     assertThat(found.get().trackingNumber).isEqualTo("TRACK-001")
+    assertThat(found.get().billOfLading).isEqualTo("BL-OCEAN-001")
+    assertThat(found.get().containerNumber).isEqualTo("CONT-001")
+    assertThat(found.get().lot).isEqualTo("LOT-A")
+    assertThat(found.get().seals).isEqualTo("SEAL-123")
   }
 
   @Test
@@ -51,6 +59,11 @@ class DeliveryNoteCodigTest {
     assertThat(note.shippingDate).isNull()
     assertThat(note.deliveryDate).isNull()
     assertThat(note.packageCount).isNull()
+    assertThat(note.arrivalDate).isNull()
+    assertThat(note.containerNumber).isNull()
+    assertThat(note.billOfLading).isNull()
+    assertThat(note.lot).isNull()
+    assertThat(note.seals).isNull()
     assertThat(note.signedBy).isNull()
   }
 
@@ -119,6 +132,11 @@ class DeliveryNoteCodigTest {
     note.shippingDate = LocalDate.of(2026, 3, 10)
     note.deliveryDate = LocalDate.of(2026, 3, 15)
     note.shippingAddress = "456 Shipping Ave"
+    note.arrivalDate = LocalDate.of(2026, 3, 16)
+    note.billOfLading = "BL-LOG-01"
+    note.containerNumber = "CONT-LOG-01"
+    note.lot = "LOT-LOG"
+    note.seals = "SEAL-LOG"
     note.packageCount = 3
     note.signedBy = "Jean Dupont"
     note.signatureDate = LocalDate.of(2026, 3, 15)
@@ -129,6 +147,11 @@ class DeliveryNoteCodigTest {
     assertThat(found.shippingDate).isEqualTo(LocalDate.of(2026, 3, 10))
     assertThat(found.deliveryDate).isEqualTo(LocalDate.of(2026, 3, 15))
     assertThat(found.shippingAddress).isEqualTo("456 Shipping Ave")
+    assertThat(found.arrivalDate).isEqualTo(LocalDate.of(2026, 3, 16))
+    assertThat(found.billOfLading).isEqualTo("BL-LOG-01")
+    assertThat(found.containerNumber).isEqualTo("CONT-LOG-01")
+    assertThat(found.lot).isEqualTo("LOT-LOG")
+    assertThat(found.seals).isEqualTo("SEAL-LOG")
     assertThat(found.packageCount).isEqualTo(3)
     assertThat(found.signedBy).isEqualTo("Jean Dupont")
     assertThat(found.observations).isEqualTo("Handle with care")

--- a/src/test/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneTest.kt
@@ -2,10 +2,13 @@ package fr.axl.lvy.delivery
 
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientRepository
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigRepository
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.order.OrderNetstoneRepository
+import java.math.BigDecimal
 import java.time.LocalDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -21,6 +24,8 @@ class DeliveryNoteNetstoneTest {
   @Autowired lateinit var orderCodigRepository: OrderCodigRepository
   @Autowired lateinit var orderNetstoneRepository: OrderNetstoneRepository
   @Autowired lateinit var clientRepository: ClientRepository
+  @Autowired lateinit var deliveryNoteNetstoneService: DeliveryNoteNetstoneService
+  @Autowired lateinit var documentLineRepository: DocumentLineRepository
 
   private fun createOrderNetstone(number: String): OrderNetstone {
     val client = clientRepository.save(Client("CLI-DB-$number", "Client"))
@@ -34,6 +39,7 @@ class DeliveryNoteNetstoneTest {
     val orderNetstone = createOrderNetstone("CB-DB-01")
     val note = DeliveryNoteNetstone("BLB-2026-0001", orderNetstone)
     note.containerNumber = "CONT-001"
+    note.billOfLading = "BL-001"
     note.lot = "LOT-A"
     note.seals = "SEAL-123"
     deliveryNoteNetstoneRepository.save(note)
@@ -42,6 +48,7 @@ class DeliveryNoteNetstoneTest {
     assertThat(found).isPresent
     assertThat(found.get().deliveryNoteNumber).isEqualTo("BLB-2026-0001")
     assertThat(found.get().containerNumber).isEqualTo("CONT-001")
+    assertThat(found.get().billOfLading).isEqualTo("BL-001")
     assertThat(found.get().lot).isEqualTo("LOT-A")
     assertThat(found.get().seals).isEqualTo("SEAL-123")
   }
@@ -126,5 +133,48 @@ class DeliveryNoteNetstoneTest {
     assertThat(found.arrivalDate).isEqualTo(LocalDate.of(2026, 3, 20))
     assertThat(found.pdfPath).isEqualTo("/documents/blb-001.pdf")
     assertThat(found.observations).isEqualTo("Fragile cargo")
+  }
+
+  @Test
+  fun saveWithLines_generates_netstone_out_number_and_delivery_lines() {
+    val orderNetstone = createOrderNetstone("CB-DB-08")
+    val line =
+      DocumentLine(DocumentLine.DocumentType.SALES_NETSTONE, 0L, "Delivered product").apply {
+        quantity = BigDecimal("12.50")
+        unit = "kg"
+        recalculate()
+      }
+
+    val saved =
+      deliveryNoteNetstoneService.saveWithLines(
+        DeliveryNoteNetstone("", orderNetstone),
+        listOf(line),
+      )
+
+    assertThat(saved.deliveryNoteNumber).startsWith("Netst/OUT/")
+    assertThat(deliveryNoteNetstoneService.findByOrderNetstoneId(orderNetstone.id!!)?.id)
+      .isEqualTo(saved.id)
+    val lines =
+      documentLineRepository.findByDocumentTypeAndDocumentIdOrderByPosition(
+        DocumentLine.DocumentType.DELIVERY_NETSTONE,
+        saved.id!!,
+      )
+    assertThat(lines).hasSize(1)
+    assertThat(lines.first().designation).isEqualTo("Delivered product")
+    assertThat(lines.first().quantity).isEqualByComparingTo("12.50")
+  }
+
+  @Test
+  fun previewNextDeliveryNoteNumber_does_not_create_delivery_before_save() {
+    val orderNetstone = createOrderNetstone("CB-DB-09")
+
+    val preview = deliveryNoteNetstoneService.previewNextDeliveryNoteNumber()
+
+    assertThat(preview).startsWith("Netst/OUT/")
+    assertThat(deliveryNoteNetstoneRepository.findByDeletedAtIsNull()).isEmpty()
+
+    val saved = deliveryNoteNetstoneService.save(DeliveryNoteNetstone("", orderNetstone))
+
+    assertThat(saved.deliveryNoteNumber).isEqualTo(preview)
   }
 }

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -4,6 +4,8 @@ import fr.axl.lvy.TestDataFactory
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientRepository
 import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.delivery.DeliveryNoteNetstone
+import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.fiscalposition.FiscalPosition
 import fr.axl.lvy.fiscalposition.FiscalPositionRepository
@@ -11,6 +13,13 @@ import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigRepository
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.order.OrderNetstoneService
+import fr.axl.lvy.product.Product
+import fr.axl.lvy.product.ProductRepository
+import fr.axl.lvy.product.ProductService
+import fr.axl.lvy.sale.SalesCodig
+import fr.axl.lvy.sale.SalesCodigRepository
+import fr.axl.lvy.sale.SalesNetstone
+import fr.axl.lvy.sale.SalesNetstoneService
 import fr.axl.lvy.user.User
 import java.io.ByteArrayInputStream
 import java.math.BigDecimal
@@ -37,6 +46,11 @@ class PdfServiceTest {
   @Autowired lateinit var clientRepository: ClientRepository
   @Autowired lateinit var clientService: ClientService
   @Autowired lateinit var fiscalPositionRepository: FiscalPositionRepository
+  @Autowired lateinit var deliveryNoteNetstoneService: DeliveryNoteNetstoneService
+  @Autowired lateinit var salesCodigRepository: SalesCodigRepository
+  @Autowired lateinit var salesNetstoneService: SalesNetstoneService
+  @Autowired lateinit var productRepository: ProductRepository
+  @Autowired lateinit var productService: ProductService
   @Autowired lateinit var testData: TestDataFactory
 
   private val sampleLogoData =
@@ -178,6 +192,117 @@ class PdfServiceTest {
     assertThat(text).contains("Import/Export Hors Europe")
     assertThat(text).contains("One batch per pallet")
     assertThat(text).contains("Supplier note line AND INSURANCE")
+  }
+
+  /** Verifies the delivery note PDF renders the Netstone delivery-specific logistics fields. */
+  @Test
+  fun generateDeliveryPdf_renders_delivery_note_sections() {
+    val codigCompany =
+      clientService.findDefaultCodigCompany().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-CODIG", "CoDIG SAS").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.CODIG
+          }
+        )
+      }
+    codigCompany.billingAddress = "12 rue de Paris\n75001 Paris\nFrance"
+    codigCompany.vatNumber = "FR12345678901"
+    clientService.save(codigCompany)
+
+    val customer = clientRepository.save(Client("CLI-PDF-DEL-CUST", "Final Customer"))
+    val orderCodig =
+      orderCodigRepository.save(
+        OrderCodig("Cod_PO_001", customer, LocalDate.of(2026, 2, 10)).apply { currency = "USD" }
+      )
+    val salesCodig =
+      salesCodigRepository.save(
+        SalesCodig("SO-CODIG-PDF", customer, LocalDate.of(2026, 2, 10)).apply {
+          this.orderCodig = orderCodig
+          shippingAddress = "Warehouse A\nLe Havre\nFrance"
+        }
+      )
+    val sale =
+      SalesNetstone("NST_SO_001", salesCodig).apply {
+        shippingAddress = "Warehouse A\nLe Havre\nFrance"
+        incoterms = "CFR"
+        incotermLocation = "Le Havre"
+      }
+    val product =
+      productRepository.save(
+        Product("PRD-PDF-DEL", "N-METHYLGLUCAMINE").apply {
+          unit = "kg"
+          hsCode = "292219"
+          madeIn = "China"
+          specifications = "White crystalline powder"
+        }
+      )
+    val saleLine =
+      DocumentLine(DocumentLine.DocumentType.SALES_NETSTONE, 0L, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("100.00")
+        unit = "kg"
+        hsCode = product.hsCode
+        madeIn = product.madeIn
+        clientProductCode = "PC-OLD-001"
+        recalculate()
+      }
+    val savedSale = salesNetstoneService.saveWithLines(sale, listOf(saleLine))
+    product.replaceClientProductCodes(listOf(codigCompany to "PC-CURRENT-001"))
+    productService.save(product)
+    val order =
+      orderNetstoneService.save(
+        OrderNetstone("NST-PO-PDF", orderCodig).apply {
+          incoterms = "CFR"
+          incotermLocation = "Le Havre"
+          deliveryLocation = savedSale.shippingAddress
+        }
+      )
+    val delivery =
+      DeliveryNoteNetstone("", order).apply {
+        arrivalDate = LocalDate.of(2026, 5, 4)
+        billOfLading = "BL-7788"
+        containerNumber = "CONT-42"
+        seals = "SEAL-99"
+        lot = "LOT-A"
+      }
+    val deliveryLine =
+      DocumentLine(DocumentLine.DocumentType.DELIVERY_NETSTONE, 0L, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("80.00")
+        unit = "kg"
+        hsCode = product.hsCode
+        madeIn = product.madeIn
+        clientProductCode = "PC-OLD-001"
+        recalculate()
+      }
+    val savedDelivery = deliveryNoteNetstoneService.saveWithLines(delivery, listOf(deliveryLine))
+
+    val text = extractText(pdfService.generateDeliveryNetstonePdf(savedDelivery.id!!))
+
+    assertThat(text).contains(savedDelivery.deliveryNoteNumber)
+    assertThat(text).contains("DELIVERY ADDRESS:")
+    assertThat(text).contains("Warehouse A")
+    assertThat(text).contains("CUSTOMER ADDRESS:")
+    assertThat(text).contains("CoDIG SAS")
+    assertThat(text).contains("TVA: FR12345678901")
+    assertThat(text).contains("NST_SO_001")
+    assertThat(text).contains("04/05/2026")
+    assertThat(text).contains("Cod_PO_001")
+    assertThat(text).contains("CFR Le Havre")
+    assertThat(text).contains("N-METHYLGLUCAMINE")
+    assertThat(text).contains("100,00 kg")
+    assertThat(text).contains("80,00 kg")
+    assertThat(text).contains("PO : Cod_PO_001 / CFR Le Havre / Made in : China")
+    assertThat(text).contains("White crystalline powder")
+    assertThat(text).contains("PC: PC-CURRENT-001")
+    assertThat(text).doesNotContain("PC: PC-OLD-001")
+    assertThat(text).contains("HS CODE : 292219")
+    assertThat(text).contains("BL : BL-7788 / CONT-42")
+    assertThat(text).doesNotContain("N° de conteneur")
+    assertThat(text).contains("SEALS : SEAL-99")
+    assertThat(text).contains("LOT : LOT-A")
   }
 
   private fun extractText(bytes: ByteArray): String =

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -591,6 +591,131 @@ class PdfServiceTest {
       .isInstanceOf(IllegalArgumentException::class.java)
   }
 
+  /**
+   * Delivery line with no product + sale line sharing only the designation. Exercises the
+   * designation-match fallback in DeliveryPdfLine.from.
+   */
+  @Test
+  fun generateDeliveryNetstonePdf_matches_sale_line_by_designation_when_no_product_on_delivery() {
+    val customer = clientRepository.save(Client("CLI-PDF-DSN", "Designation Match"))
+    val orderCodig =
+      orderCodigRepository.save(OrderCodig("COD-DSN", customer, LocalDate.of(2026, 6, 1)))
+    val salesCodig =
+      salesCodigRepository.save(
+        SalesCodig("SO-DSN", customer, LocalDate.of(2026, 6, 1)).apply {
+          this.orderCodig = orderCodig
+        }
+      )
+    val saleProduct = productRepository.save(Product("PRD-DSN", "Designation Widget"))
+    val saleLine =
+      DocumentLine(DocumentLine.DocumentType.SALES_NETSTONE, 0L, saleProduct.name).apply {
+        this.product = saleProduct
+        quantity = BigDecimal("42.00")
+        unit = "kg"
+        recalculate()
+      }
+    val sale =
+      salesNetstoneService.saveWithLines(SalesNetstone("NST-DSN", salesCodig), listOf(saleLine))
+    val order = orderNetstoneService.save(OrderNetstone("NST-PO-DSN", orderCodig))
+    val deliveryLine =
+      DocumentLine(DocumentLine.DocumentType.DELIVERY_NETSTONE, 0L, saleProduct.name).apply {
+        quantity = BigDecimal("30.00")
+        unit = "kg"
+        recalculate()
+      }
+    val savedDelivery =
+      deliveryNoteNetstoneService.saveWithLines(
+        DeliveryNoteNetstone("", order),
+        listOf(deliveryLine),
+      )
+
+    val text = extractText(pdfService.generateDeliveryNetstonePdf(savedDelivery.id!!))
+
+    assertThat(text).contains("Designation Widget")
+    assertThat(text).contains("42,00 kg")
+    assertThat(text).contains("30,00 kg")
+    assertThat(sale.id).isNotNull
+  }
+
+  /**
+   * Product has a client code for a client that is neither the CoDIG company nor the customer.
+   * Verifies the fallback to findFirstClientProductCode when no pc-client matches.
+   */
+  @Test
+  fun generateDeliveryNetstonePdf_falls_back_to_first_product_code_when_no_pc_client_matches() {
+    val unrelated = clientRepository.save(Client("CLI-UNREL", "Unrelated Ref Holder"))
+    val customer = clientRepository.save(Client("CLI-PDF-FB", "Fallback Customer"))
+    val orderCodig =
+      orderCodigRepository.save(OrderCodig("COD-FB", customer, LocalDate.of(2026, 7, 1)))
+    val product =
+      productRepository.save(
+        Product("PRD-FB", "Fallback Product").apply {
+          replaceClientProductCodes(listOf(unrelated to "PC-FALLBACK"))
+        }
+      )
+    productService.save(product)
+    val order = orderNetstoneService.save(OrderNetstone("NST-PO-FB", orderCodig))
+    val deliveryLine =
+      DocumentLine(DocumentLine.DocumentType.DELIVERY_NETSTONE, 0L, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("5.00")
+        unit = "kg"
+        recalculate()
+      }
+    val savedDelivery =
+      deliveryNoteNetstoneService.saveWithLines(
+        DeliveryNoteNetstone("", order),
+        listOf(deliveryLine),
+      )
+
+    val text = extractText(pdfService.generateDeliveryNetstonePdf(savedDelivery.id!!))
+
+    assertThat(text).contains("PC: PC-FALLBACK")
+  }
+
+  /**
+   * Codig delivery whose order has no linked sale. Exercises the `sale == null` branch and uses
+   * `order.clientReference` as the customer reference.
+   */
+  @Test
+  fun generateDeliveryCodigPdf_without_linked_sale_uses_order_client_reference() {
+    val customer = clientRepository.save(Client("CLI-CD-NOSALE", "Direct Customer"))
+    val orderCodig =
+      orderCodigRepository.save(
+        OrderCodig("COD-NO-SALE-2", customer, LocalDate.of(2026, 8, 1)).apply {
+          clientReference = "PO-DIRECT-123"
+          shippingAddress = "Dock 9\nRotterdam"
+        }
+      )
+    val product =
+      productRepository.save(
+        Product("PRD-CD-NS", "Direct Product").apply {
+          unit = "kg"
+          madeIn = "France"
+        }
+      )
+    val orderLine =
+      DocumentLine(DocumentLine.DocumentType.ORDER_CODIG, orderCodig.id!!, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("10.00")
+        unit = "kg"
+        recalculate()
+      }
+    documentLineRepository.save(orderLine)
+    val delivery =
+      deliveryNoteCodigService.save(
+        DeliveryNoteCodig("", orderCodig, customer).apply {
+          shippingAddress = orderCodig.shippingAddress
+        }
+      )
+
+    val text = extractText(pdfService.generateDeliveryCodigPdf(delivery.id!!))
+
+    assertThat(text).contains("PO-DIRECT-123")
+    assertThat(text).contains("Direct Product")
+    assertThat(text).contains("10,00 kg")
+  }
+
   private fun extractText(bytes: ByteArray): String =
     PDDocument.load(ByteArrayInputStream(bytes)).use { doc -> PDFTextStripper().getText(doc) }
 

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -4,13 +4,17 @@ import fr.axl.lvy.TestDataFactory
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientRepository
 import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.delivery.DeliveryNoteCodig
+import fr.axl.lvy.delivery.DeliveryNoteCodigService
 import fr.axl.lvy.delivery.DeliveryNoteNetstone
 import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.fiscalposition.FiscalPosition
 import fr.axl.lvy.fiscalposition.FiscalPositionRepository
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigRepository
+import fr.axl.lvy.order.OrderCodigService
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.order.OrderNetstoneService
 import fr.axl.lvy.product.Product
@@ -18,6 +22,7 @@ import fr.axl.lvy.product.ProductRepository
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodig
 import fr.axl.lvy.sale.SalesCodigRepository
+import fr.axl.lvy.sale.SalesCodigService
 import fr.axl.lvy.sale.SalesNetstone
 import fr.axl.lvy.sale.SalesNetstoneService
 import fr.axl.lvy.user.User
@@ -41,13 +46,17 @@ import org.springframework.transaction.annotation.Transactional
 class PdfServiceTest {
 
   @Autowired lateinit var pdfService: PdfService
+  @Autowired lateinit var orderCodigService: OrderCodigService
   @Autowired lateinit var orderNetstoneService: OrderNetstoneService
   @Autowired lateinit var orderCodigRepository: OrderCodigRepository
   @Autowired lateinit var clientRepository: ClientRepository
   @Autowired lateinit var clientService: ClientService
   @Autowired lateinit var fiscalPositionRepository: FiscalPositionRepository
+  @Autowired lateinit var deliveryNoteCodigService: DeliveryNoteCodigService
   @Autowired lateinit var deliveryNoteNetstoneService: DeliveryNoteNetstoneService
+  @Autowired lateinit var documentLineRepository: DocumentLineRepository
   @Autowired lateinit var salesCodigRepository: SalesCodigRepository
+  @Autowired lateinit var salesCodigService: SalesCodigService
   @Autowired lateinit var salesNetstoneService: SalesNetstoneService
   @Autowired lateinit var productRepository: ProductRepository
   @Autowired lateinit var productService: ProductService
@@ -303,6 +312,123 @@ class PdfServiceTest {
     assertThat(text).doesNotContain("N° de conteneur")
     assertThat(text).contains("SEALS : SEAL-99")
     assertThat(text).contains("LOT : LOT-A")
+  }
+
+  /** Verifies the Codig delivery note PDF uses the customer delivery address and client PO ref. */
+  @Test
+  fun generateCodigDeliveryPdf_renders_customer_delivery_and_client_reference() {
+    val codigCompany =
+      clientService.findDefaultCodigCompany().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-CODIG-DLV", "CoDIG SAS").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.CODIG
+          }
+        )
+      }
+    codigCompany.billingAddress = "12 rue de Paris\n75001 Paris\nFrance"
+    codigCompany.vatNumber = "FRCODIG123"
+    codigCompany.logoData = sampleLogoData
+    clientService.save(codigCompany)
+
+    val customer =
+      clientRepository.save(
+        Client("CLI-PDF-CODIG-CUST", "Customer Delivery").apply {
+          billingAddress = "1 Buyer Road\nLondon"
+        }
+      )
+    val orderCodig =
+      orderCodigRepository.save(
+        OrderCodig("COD-ORDER-PDF", customer, LocalDate.of(2026, 3, 1)).apply {
+          clientReference = "PO-CUSTOMER-777"
+          shippingAddress = "Customer Warehouse\nRotterdam\nNetherlands"
+          incoterms = "DAP"
+          incotermLocation = "Rotterdam"
+        }
+      )
+    val sale =
+      salesCodigRepository.save(
+        SalesCodig("cod_SO_001", customer, LocalDate.of(2026, 3, 1)).apply {
+          this.orderCodig = orderCodig
+          clientReference = "PO-CUSTOMER-777"
+          shippingAddress = orderCodig.shippingAddress
+          incoterms = orderCodig.incoterms
+          incotermLocation = orderCodig.incotermLocation
+        }
+      )
+    val product =
+      productRepository.save(
+        Product("PRD-PDF-CODIG-DLV", "SODIUM GLUCONATE").apply {
+          unit = "kg"
+          hsCode = "291816"
+          madeIn = "China"
+          specifications = "Technical grade"
+        }
+      )
+    product.replaceClientProductCodes(listOf(customer to "PC-CODIG-001"))
+    productService.save(product)
+
+    val saleLine =
+      DocumentLine(DocumentLine.DocumentType.SALES_CODIG, 0L, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("50.00")
+        unit = "kg"
+        hsCode = product.hsCode
+        madeIn = product.madeIn
+        recalculate()
+      }
+    documentLineRepository.save(
+      DocumentLine(DocumentLine.DocumentType.SALES_CODIG, sale.id!!, saleLine.designation).apply {
+        copyFieldsFrom(saleLine)
+      }
+    )
+    salesCodigRepository.flush()
+    val orderLine =
+      DocumentLine(DocumentLine.DocumentType.ORDER_CODIG, 0L, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("50.00")
+        unit = "kg"
+        hsCode = product.hsCode
+        madeIn = product.madeIn
+        recalculate()
+      }
+    documentLineRepository.save(
+      DocumentLine(DocumentLine.DocumentType.ORDER_CODIG, orderCodig.id!!, orderLine.designation)
+        .apply { copyFieldsFrom(orderLine) }
+    )
+    val delivery =
+      deliveryNoteCodigService.save(
+        DeliveryNoteCodig("", orderCodig, customer).apply {
+          shippingAddress = orderCodig.shippingAddress
+          arrivalDate = LocalDate.of(2026, 5, 8)
+          billOfLading = "BL-CODIG-001"
+          containerNumber = "CONT-CODIG"
+          seals = "SEAL-CODIG"
+          lot = "LOT-CODIG"
+        }
+      )
+
+    val text = extractText(pdfService.generateDeliveryCodigPdf(delivery.id!!))
+
+    assertThat(text).contains(delivery.deliveryNoteNumber)
+    assertThat(text).contains("TVA: FRCODIG123")
+    assertThat(text).contains("DELIVERY ADDRESS:")
+    assertThat(text).contains("Customer Warehouse")
+    assertThat(text).doesNotContain("CUSTOMER ADDRESS:")
+    assertThat(text).contains("cod_SO_001")
+    assertThat(text).contains("08/05/2026")
+    assertThat(text).contains("PO-CUSTOMER-777")
+    assertThat(text).contains("DAP Rotterdam")
+    assertThat(text).contains("SODIUM GLUCONATE")
+    assertThat(text).contains("50,00 kg")
+    assertThat(text).contains("PO : PO-CUSTOMER-777 / DAP Rotterdam / Made in : China")
+    assertThat(text).contains("Technical grade")
+    assertThat(text).contains("PC: PC-CODIG-001")
+    assertThat(text).contains("HS CODE : 291816")
+    assertThat(text).contains("BL : BL-CODIG-001 / CONT-CODIG")
+    assertThat(text).contains("SEALS : SEAL-CODIG")
+    assertThat(text).contains("LOT : LOT-CODIG")
   }
 
   private fun extractText(bytes: ByteArray): String =

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -431,6 +431,166 @@ class PdfServiceTest {
     assertThat(text).contains("LOT : LOT-CODIG")
   }
 
+  /**
+   * No uploaded logo and no classpath logo → generated wordmark fallback still renders an image.
+   */
+  @Test
+  fun generatePdf_falls_back_to_generated_logo_when_no_uploaded_logo() {
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData = null
+    val client = clientRepository.save(Client("CLI-PDF-NOLOGO", "No Logo Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-NOLOGO", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    val imageCount = countImages(pdfService.generateOrderNetstonePdf(saved.id!!))
+
+    assertThat(imageCount).isGreaterThan(0)
+  }
+
+  /** Malformed base64 payload → normalization fails → fallback renders. */
+  @Test
+  fun generatePdf_falls_back_when_logo_is_invalid_base64() {
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData =
+      "data:image/png;base64,!!!not-valid-base64!!!"
+    val client = clientRepository.save(Client("CLI-PDF-BADB64", "Bad Base64 Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-BADB64", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    assertThat(countImages(pdfService.generateOrderNetstonePdf(saved.id!!))).isGreaterThan(0)
+  }
+
+  /** Missing `;base64,` marker → normalization rejects → fallback renders. */
+  @Test
+  fun generatePdf_falls_back_when_logo_has_no_base64_marker() {
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData = "data:image/png,abcdef"
+    val client = clientRepository.save(Client("CLI-PDF-NOMARK", "No Marker Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-NOMARK", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    assertThat(countImages(pdfService.generateOrderNetstonePdf(saved.id!!))).isGreaterThan(0)
+  }
+
+  /** Missing `data:` prefix → normalization rejects → fallback renders. */
+  @Test
+  fun generatePdf_falls_back_when_logo_has_no_data_prefix() {
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData =
+      "image/png;base64,iVBORw0KGgo="
+    val client = clientRepository.save(Client("CLI-PDF-NODP", "No Data Prefix Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-NODP", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    assertThat(countImages(pdfService.generateOrderNetstonePdf(saved.id!!))).isGreaterThan(0)
+  }
+
+  /**
+   * Unknown magic bytes AND unknown declared content type → normalization rejects → fallback
+   * renders.
+   */
+  @Test
+  fun generatePdf_falls_back_when_logo_format_is_unknown() {
+    val gibberish =
+      java.util.Base64.getEncoder().encodeToString(byteArrayOf(1, 2, 3, 4, 5, 6, 7, 8))
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData =
+      "data:image/webp;base64,$gibberish"
+    val client = clientRepository.save(Client("CLI-PDF-UNKN", "Unknown Format Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-UNKN", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    assertThat(countImages(pdfService.generateOrderNetstonePdf(saved.id!!))).isGreaterThan(0)
+  }
+
+  /**
+   * `image/jpg` is a common but non-standard content type. Verify it normalizes to `image/jpeg`.
+   */
+  @Test
+  fun generatePdf_accepts_declared_image_jpg_content_type() {
+    val jpegOut = java.io.ByteArrayOutputStream()
+    val img = java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_RGB)
+    javax.imageio.ImageIO.write(img, "jpg", jpegOut)
+    val encoded = java.util.Base64.getEncoder().encodeToString(jpegOut.toByteArray())
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData =
+      "data:image/jpg;base64,$encoded"
+    val client = clientRepository.save(Client("CLI-PDF-JPG", "Jpg Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-JPG", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    assertThat(countImages(pdfService.generateOrderNetstonePdf(saved.id!!))).isGreaterThan(0)
+  }
+
+  /** Uncommon currency codes pass through as-is; known codes render their symbol. */
+  @Test
+  fun generatePdf_renders_various_currency_symbols() {
+    listOf("EUR" to "€", "USD" to "$", "GBP" to "£", "CNY" to "¥", "RMB" to "¥", "JPY" to "JPY")
+      .forEachIndexed { index, (code, expected) ->
+        val client = clientRepository.save(Client("CLI-PDF-CUR-$index", "Currency Client $code"))
+        val orderCodig =
+          orderCodigRepository.save(
+            OrderCodig("CA-PDF-CUR-$index", client, LocalDate.now()).apply { currency = code }
+          )
+        val line =
+          DocumentLine(DocumentLine.DocumentType.ORDER_NETSTONE, 0L, "Item").apply {
+            quantity = BigDecimal.ONE
+            unitPriceExclTax = BigDecimal("42.00")
+            vatRate = BigDecimal.ZERO
+            discountPercent = BigDecimal.ZERO
+            recalculate()
+          }
+        val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), listOf(line))
+
+        val text = extractText(pdfService.generateOrderNetstonePdf(saved.id!!))
+
+        assertThat(text).contains(expected)
+      }
+  }
+
+  /** Null incoterm + null location should render without error and without stray separator. */
+  @Test
+  fun generateDeliveryCodigPdf_handles_missing_incoterm_and_sale() {
+    val customer = clientRepository.save(Client("CLI-PDF-NOSALE", "No Sale Customer"))
+    val orderCodig =
+      orderCodigRepository.save(
+        OrderCodig("COD-NO-SALE", customer, LocalDate.of(2026, 4, 1)).apply {
+          clientReference = "PO-DIRECT-42"
+          shippingAddress = "Dock 7\nHamburg"
+        }
+      )
+    val delivery =
+      deliveryNoteCodigService.save(
+        DeliveryNoteCodig("", orderCodig, customer).apply {
+          shippingAddress = orderCodig.shippingAddress
+          arrivalDate = LocalDate.of(2026, 4, 15)
+        }
+      )
+
+    val text = extractText(pdfService.generateDeliveryCodigPdf(delivery.id!!))
+
+    assertThat(text).contains(delivery.deliveryNoteNumber)
+    assertThat(text).contains("Dock 7")
+    assertThat(text).contains("PO-DIRECT-42")
+  }
+
+  /** Unknown note id → IllegalArgumentException. */
+  @Test
+  fun generateDeliveryNetstonePdf_throws_for_unknown_note() {
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+        pdfService.generateDeliveryNetstonePdf(-1L)
+      }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  /** Unknown note id → IllegalArgumentException. */
+  @Test
+  fun generateDeliveryCodigPdf_throws_for_unknown_note() {
+    org.assertj.core.api.Assertions.assertThatThrownBy { pdfService.generateDeliveryCodigPdf(-1L) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  /** Unknown order id → IllegalArgumentException. */
+  @Test
+  fun generateOrderNetstonePdf_throws_for_unknown_order() {
+    org.assertj.core.api.Assertions.assertThatThrownBy { pdfService.generateOrderNetstonePdf(-1L) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
+
   private fun extractText(bytes: ByteArray): String =
     PDDocument.load(ByteArrayInputStream(bytes)).use { doc -> PDFTextStripper().getText(doc) }
 

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -16,6 +16,9 @@ import java.io.ByteArrayInputStream
 import java.math.BigDecimal
 import java.time.LocalDate
 import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDResources
+import org.apache.pdfbox.pdmodel.graphics.form.PDFormXObject
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
 import org.apache.pdfbox.text.PDFTextStripper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -36,17 +39,27 @@ class PdfServiceTest {
   @Autowired lateinit var fiscalPositionRepository: FiscalPositionRepository
   @Autowired lateinit var testData: TestDataFactory
 
+  private val sampleLogoData =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+
+  private val sampleLogoDataWithGenericContentType =
+    sampleLogoData.replace("data:image/png;", "data:application/octet-stream;")
+
   @BeforeEach
   fun setupNetstoneOwnCompany() {
-    if (clientService.findDefaultCodigSupplier().isEmpty) {
+    val defaultSupplier = clientService.findDefaultCodigSupplier()
+    if (defaultSupplier.isEmpty) {
       val netstone =
         Client("CLI-PDF-NET", "Netstone").apply {
           type = Client.ClientType.OWN_COMPANY
           role = Client.ClientRole.OWN_COMPANY
           visibleCompany = User.Company.NETSTONE
           billingAddress = "10/F., Guangdong Investment Tower\nHong Kong"
+          logoData = sampleLogoData
         }
       clientService.save(netstone)
+    } else {
+      defaultSupplier.get().logoData = sampleLogoData
     }
   }
 
@@ -64,7 +77,33 @@ class PdfServiceTest {
     val text = extractText(pdfService.generateOrderNetstonePdf(saved.id!!))
 
     assertThat(text).contains(saved.orderNumber)
-    assertThat(text).contains("Minimal Client")
+  }
+
+  /** Verifies that the own-company logo saved on the company record is rendered into the PDF. */
+  @Test
+  fun generatePdf_uses_own_company_logo() {
+    val client = clientRepository.save(Client("CLI-PDF-LOGO", "Logo Client"))
+    val orderCodig = orderCodigRepository.save(OrderCodig("CA-PDF-LOGO", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    val imageCount = countImages(pdfService.generateOrderNetstonePdf(saved.id!!))
+
+    assertThat(imageCount).isGreaterThan(0)
+  }
+
+  /** Verifies uploaded logos still render when the browser provides a generic content type. */
+  @Test
+  fun generatePdf_normalizes_logo_content_type() {
+    clientService.findDefaultCodigSupplier().orElseThrow().logoData =
+      sampleLogoDataWithGenericContentType
+    val client = clientRepository.save(Client("CLI-PDF-LOGO-TYPE", "Logo Type Client"))
+    val orderCodig =
+      orderCodigRepository.save(OrderCodig("CA-PDF-LOGO-TYPE", client, LocalDate.now()))
+    val saved = orderNetstoneService.saveWithLines(OrderNetstone("", orderCodig), emptyList())
+
+    val imageCount = countImages(pdfService.generateOrderNetstonePdf(saved.id!!))
+
+    assertThat(imageCount).isGreaterThan(0)
   }
 
   /**
@@ -84,9 +123,18 @@ class PdfServiceTest {
     orderCodigRepository.save(orderCodig)
 
     val fiscalPosition = fiscalPositionRepository.save(FiscalPosition("Import/Export Hors Europe"))
+    val supplier =
+      clientRepository.save(
+        Client("CLI-PDF-SUP", "Supplier Chemicals").apply {
+          role = Client.ClientRole.PRODUCER
+          billingAddress = "88 Supplier Road\nBangkok\nThailand"
+          notes = "Supplier note line"
+        }
+      )
 
     val order =
       OrderNetstone("", orderCodig).apply {
+        this.supplier = supplier
         incoterms = "CIF"
         incotermLocation = "ANTWERP"
         deliveryLocation = "Port of Antwerp"
@@ -110,7 +158,14 @@ class PdfServiceTest {
 
     // header
     assertThat(text).contains(saved.orderNumber)
-    assertThat(text).contains("Zenji Pharmaceuticals")
+    assertThat(text).contains("Netstone")
+    // supplier block
+    assertThat(text).contains("Supplier Chemicals")
+    assertThat(text).contains("88 Supplier Road")
+    assertThat(text).doesNotContain("Zenji Pharmaceuticals")
+    assertThat(text).contains("DELIVERY ADDRESS:")
+    assertThat(text).doesNotContain("Dellvery")
+    assertThat(text).doesNotContain("Port of:")
     // metadata
     assertThat(text).contains("CIF")
     assertThat(text).contains("ANTWERP")
@@ -122,8 +177,25 @@ class PdfServiceTest {
     // footer
     assertThat(text).contains("Import/Export Hors Europe")
     assertThat(text).contains("One batch per pallet")
+    assertThat(text).contains("Supplier note line AND INSURANCE")
   }
 
   private fun extractText(bytes: ByteArray): String =
     PDDocument.load(ByteArrayInputStream(bytes)).use { doc -> PDFTextStripper().getText(doc) }
+
+  private fun countImages(bytes: ByteArray): Int =
+    PDDocument.load(ByteArrayInputStream(bytes)).use { doc ->
+      doc.pages.sumOf { countImages(it.resources) }
+    }
+
+  private fun countImages(resources: PDResources?): Int {
+    if (resources == null) return 0
+    return resources.xObjectNames.sumOf { name ->
+      when (val xObject = resources.getXObject(name)) {
+        is PDImageXObject -> 1
+        is PDFormXObject -> countImages(xObject.resources)
+        else -> 0
+      }
+    }
+  }
 }

--- a/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
@@ -213,6 +213,26 @@ class ProductServiceTest {
   }
 
   @Test
+  fun replaceClientProductCodes_updates_existing_client_code_without_duplicate_insert() {
+    val client = createClient("CLI-R03")
+    val product = Product(name = "Code Update")
+    product.replaceClientProductCodes(listOf(client to "OLD-001"))
+    productService.save(product)
+    productRepository.flush()
+    entityManager.clear()
+
+    val loaded = productService.findDetailedById(product.id!!).orElseThrow()
+    loaded.replaceClientProductCodes(listOf(loaded.clientProductCodes.first().client to "NEW-001"))
+    productService.save(loaded)
+    productRepository.flush()
+    entityManager.clear()
+
+    val found = productService.findDetailedById(product.id!!).orElseThrow()
+    assertThat(found.clientProductCodes).hasSize(1)
+    assertThat(found.clientProductCodes.first().code).isEqualTo("NEW-001")
+  }
+
+  @Test
   fun findClientProductCode_returns_null_for_null_client() {
     val product = Product("REF-NUL", "No Client")
     product.replaceClientProductCodes(listOf(createClient("CLI-X") to "X-001"))

--- a/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
@@ -242,6 +242,50 @@ class ProductServiceTest {
   }
 
   @Test
+  fun service_findClientProductCode_returns_code_when_present_and_null_when_absent() {
+    val client = createClient("CLI-SVC-PC")
+    val other = createClient("CLI-SVC-OTHER")
+    val product = Product(name = "Svc Product")
+    product.replaceClientProductCodes(listOf(client to "SVC-001"))
+    productService.save(product)
+    productRepository.flush()
+
+    assertThat(productService.findClientProductCode(product.id!!, client.id!!)).isEqualTo("SVC-001")
+    assertThat(productService.findClientProductCode(product.id!!, other.id!!)).isNull()
+  }
+
+  @Test
+  fun service_findFirstClientProductCode_returns_first_or_null() {
+    val client = createClient("CLI-FIRST")
+    val productWithCode = Product(name = "With Code")
+    productWithCode.replaceClientProductCodes(listOf(client to "FIRST-001"))
+    productService.save(productWithCode)
+
+    val productWithout = Product(name = "Without Code")
+    productService.save(productWithout)
+    productRepository.flush()
+
+    assertThat(productService.findFirstClientProductCode(productWithCode.id!!))
+      .isEqualTo("FIRST-001")
+    assertThat(productService.findFirstClientProductCode(productWithout.id!!)).isNull()
+  }
+
+  @Test
+  fun archive_and_delete_execute_without_error() {
+    val product = productService.save(Product(name = "To Archive"))
+    productRepository.flush()
+
+    productService.archive(product.id!!)
+    productService.delete(product.id!!)
+  }
+
+  @Test
+  fun archive_and_delete_ignore_unknown_ids() {
+    productService.archive(-99L)
+    productService.delete(-99L)
+  }
+
+  @Test
   fun validateOnUpdate_resets_mto_for_service() {
     val product = Product("REF-UPD", "Service Update")
     product.type = Product.ProductType.PRODUCT


### PR DESCRIPTION
- Use Netstone own-company logo in purchase order PDFs, with PNG/JPEG normalization and generated fallback
- Display supplier name/address instead of repeating customer/Netstone data
- Move Netstone and supplier address blocks further right
- Clean delivery block: remove "Port of", use "DELIVERY ADDRESS"
- Reorder line table columns and add double horizontal rule above headers
- Move TAXES after UNIT PRICE
- Tighten totals layout so labels sit closer to amounts
- Render supplier notes under order notes
- Append "AND INSURANCE" to the supplier note when incoterm is CIF
- Disable PDF template/resource caching for fresh downloads
- Restrict company logo uploads to PNG/JPEG
- Extend PDF tests for logo, supplier address, delivery label, notes, and CIF insurance text
