### PR TITLE
perf: add JOIN FETCH to ProductRepository.findByDeletedAtIsNull

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/product/ProductRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductRepository.kt
@@ -16,6 +16,16 @@ interface ProductRepository : JpaRepository<Product, Long> {
   )
   fun findByDeletedAtIsNullAndActiveTrue(): List<Product>
 
+  @Query(
+    """
+      SELECT DISTINCT p
+      FROM Product p
+      LEFT JOIN FETCH p.clientProductCodes c
+      LEFT JOIN FETCH c.client
+      LEFT JOIN FETCH p.suppliers s
+      WHERE p.deletedAt IS NULL
+    """
+  )
   fun findByDeletedAtIsNull(): List<Product>
 
   @Query(


### PR DESCRIPTION
Replace derived query with JOIN FETCH on clientProductCodes and suppliers so that callers of ProductService.findAll() do not trigger N+1 queries when accessing these relations.

Closes #11