### PR TITLE
perf: filter clients at DB level in form dialogs

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/client/ClientRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/client/ClientRepository.kt
@@ -41,4 +41,21 @@ interface ClientRepository : JpaRepository<Client, Long> {
     "SELECT c FROM Client c WHERE c.deletedAt IS NULL AND c.role IN ('PRODUCER', 'BOTH') AND (c.visibleCompany = :company OR c.visibleCompany = 'BOTH')"
   )
   fun findProducersVisibleFor(company: User.Company): List<Client>
+
+  /** All non-deleted clients that can act as a buyer (role CLIENT or BOTH). */
+  @Query("SELECT c FROM Client c WHERE c.deletedAt IS NULL AND c.role IN ('CLIENT', 'BOTH')")
+  fun findClients(): List<Client>
+
+  /**
+   * All non-deleted clients usable as a product supplier: producers, both-role clients, and
+   * own-company entries (for inter-company flows).
+   */
+  @Query(
+    "SELECT c FROM Client c WHERE c.deletedAt IS NULL AND c.role IN ('PRODUCER', 'BOTH', 'OWN_COMPANY')"
+  )
+  fun findSuppliersForProduct(): List<Client>
+
+  /** All non-deleted clients with the given role. */
+  @Query("SELECT c FROM Client c WHERE c.deletedAt IS NULL AND c.role = :role")
+  fun findByRole(role: Client.ClientRole): List<Client>
 }

--- a/src/main/kotlin/fr/axl/lvy/client/ClientService.kt
+++ b/src/main/kotlin/fr/axl/lvy/client/ClientService.kt
@@ -70,6 +70,16 @@ class ClientService(
   fun findProducersVisibleFor(company: User.Company): List<Client> =
     clientRepository.findProducersVisibleFor(company)
 
+  /** Clients that can act as a buyer. */
+  @Transactional(readOnly = true) fun findClients(): List<Client> = clientRepository.findClients()
+
+  /** Clients that can be set as product supplier (producers + own companies). */
+  @Transactional(readOnly = true)
+  fun findSuppliersForProduct(): List<Client> = clientRepository.findSuppliersForProduct()
+
+  @Transactional(readOnly = true)
+  fun findByRole(role: Client.ClientRole): List<Client> = clientRepository.findByRole(role)
+
   @Transactional(readOnly = true)
   fun findById(id: Long): Optional<Client> = clientRepository.findById(id)
 

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigFormDialog.kt
@@ -94,7 +94,7 @@ internal class CommandCodigFormDialog(
     status.setItems(visibleStatuses)
     status.setItemLabelGenerator(::statusLabel)
 
-    clientCombo.setItems(clientService.findAll().filter { it.isSupplierForProduct() })
+    clientCombo.setItems(clientService.findSuppliersForProduct())
     clientCombo.setItemLabelGenerator { it.name }
     clientCombo.addValueChangeListener { event ->
       val client = event.value ?: return@addValueChangeListener

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
@@ -89,7 +89,7 @@ internal class CommandNetstoneFormDialog(
     allIncoterms = incotermService.findAll()
     incotermCombo.setItems(allIncoterms)
     incotermCombo.setItemLabelGenerator { it.name }
-    supplierCombo.setItems(clientService.findAll().filter { it.isSupplierForProduct() })
+    supplierCombo.setItems(clientService.findSuppliersForProduct())
     supplierCombo.setItemLabelGenerator { it.name }
     paymentTermCombo.setItems(paymentTermService.findAll())
     paymentTermCombo.setItemLabelGenerator { it.label }

--- a/src/main/kotlin/fr/axl/lvy/product/ui/ProductFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ui/ProductFormDialog.kt
@@ -48,9 +48,9 @@ internal class ProductFormDialog(
   private val madeIn = ComboBox<String>("Origine")
   private val active = Checkbox("Actif")
   private val clientCodeRows = VerticalLayout()
-  private val availableClients: List<Client> = clientService.findAll().filter { it.isClient() }
+  private val availableClients: List<Client> = clientService.findClients()
   private val availableSuppliers: List<Client> =
-    clientService.findAll().filter { it.role == Client.ClientRole.PRODUCER }
+    clientService.findByRole(Client.ClientRole.PRODUCER)
   private val clientCodeEntries = mutableListOf<ClientCodeRow>()
 
   init {

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigFormDialog.kt
@@ -98,7 +98,7 @@ internal class SalesCodigFormDialog(
       }
     }
 
-    clientCombo.setItems(clientService.findAll().filter { it.isClient() })
+    clientCombo.setItems(clientService.findClients())
     clientCombo.setItemLabelGenerator { it.name }
     clientCombo.addValueChangeListener { event ->
       val client = event.value ?: return@addValueChangeListener

--- a/src/test/kotlin/fr/axl/lvy/client/ClientServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/client/ClientServiceTest.kt
@@ -112,6 +112,76 @@ class ClientServiceTest {
   }
 
   @Test
+  fun findClients_returns_roles_CLIENT_and_BOTH() {
+    val clientOnly = Client("CLI-FC-C", "Client Only")
+    clientOnly.role = Client.ClientRole.CLIENT
+    clientService.save(clientOnly)
+
+    val producer = Client("CLI-FC-P", "Producer")
+    producer.role = Client.ClientRole.PRODUCER
+    clientService.save(producer)
+
+    val both = Client("CLI-FC-B", "Both")
+    both.role = Client.ClientRole.BOTH
+    clientService.save(both)
+
+    val ownCo = Client("CLI-FC-O", "Own Company")
+    ownCo.role = Client.ClientRole.OWN_COMPANY
+    clientService.save(ownCo)
+
+    val result = clientService.findClients()
+    assertThat(result).anyMatch { it.clientCode == "CLI-FC-C" }
+    assertThat(result).anyMatch { it.clientCode == "CLI-FC-B" }
+    assertThat(result).noneMatch { it.clientCode == "CLI-FC-P" }
+    assertThat(result).noneMatch { it.clientCode == "CLI-FC-O" }
+  }
+
+  @Test
+  fun findSuppliersForProduct_returns_producers_both_and_own_companies() {
+    val clientOnly = Client("CLI-SFP-C", "Client Only")
+    clientOnly.role = Client.ClientRole.CLIENT
+    clientService.save(clientOnly)
+
+    val producer = Client("CLI-SFP-P", "Producer")
+    producer.role = Client.ClientRole.PRODUCER
+    clientService.save(producer)
+
+    val both = Client("CLI-SFP-B", "Both")
+    both.role = Client.ClientRole.BOTH
+    clientService.save(both)
+
+    val ownCo = Client("CLI-SFP-O", "Own Company")
+    ownCo.role = Client.ClientRole.OWN_COMPANY
+    clientService.save(ownCo)
+
+    val result = clientService.findSuppliersForProduct()
+    assertThat(result).anyMatch { it.clientCode == "CLI-SFP-P" }
+    assertThat(result).anyMatch { it.clientCode == "CLI-SFP-B" }
+    assertThat(result).anyMatch { it.clientCode == "CLI-SFP-O" }
+    assertThat(result).noneMatch { it.clientCode == "CLI-SFP-C" }
+  }
+
+  @Test
+  fun findByRole_filters_exact_role() {
+    val producerOne = Client("CLI-ROLE-P1", "Producer One")
+    producerOne.role = Client.ClientRole.PRODUCER
+    clientService.save(producerOne)
+
+    val producerTwo = Client("CLI-ROLE-P2", "Producer Two")
+    producerTwo.role = Client.ClientRole.PRODUCER
+    clientService.save(producerTwo)
+
+    val both = Client("CLI-ROLE-B", "Both")
+    both.role = Client.ClientRole.BOTH
+    clientService.save(both)
+
+    val result = clientService.findByRole(Client.ClientRole.PRODUCER)
+    assertThat(result).anyMatch { it.clientCode == "CLI-ROLE-P1" }
+    assertThat(result).anyMatch { it.clientCode == "CLI-ROLE-P2" }
+    assertThat(result).noneMatch { it.clientCode == "CLI-ROLE-B" }
+  }
+
+  @Test
   fun findByType_filters_own_companies() {
     val ownCompany = Client("CLI-OWN", "My Company A")
     ownCompany.type = Client.ClientType.OWN_COMPANY


### PR DESCRIPTION
Replaces `clientService.findAll().filter { … }` in four dialogs with dedicated repository queries so role filtering happens in SQL.

Added:
- `ClientRepository.findClients()` — CLIENT/BOTH
- `ClientRepository.findSuppliersForProduct()` — PRODUCER/BOTH/OWN_COMPANY
- `ClientRepository.findByRole(role)` — strict role match

Callers updated:
- CommandCodigFormDialog
- CommandNetstoneFormDialog
- SalesCodigFormDialog
- ProductFormDialog

Closes #9