### PR TITLE
perf: eager-fetch product on DocumentLine in services

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/documentline/DocumentLineRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/DocumentLineRepository.kt
@@ -1,9 +1,27 @@
 package fr.axl.lvy.documentline
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface DocumentLineRepository : JpaRepository<DocumentLine, Long> {
   fun findByDocumentTypeAndDocumentIdOrderByPosition(
+    documentType: DocumentLine.DocumentType,
+    documentId: Long,
+  ): List<DocumentLine>
+
+  /**
+   * Same as [findByDocumentTypeAndDocumentIdOrderByPosition] but eagerly fetches the product to
+   * avoid N+1 queries when callers iterate lines and access [DocumentLine.product].
+   */
+  @Query(
+    """
+      SELECT dl FROM DocumentLine dl
+      LEFT JOIN FETCH dl.product
+      WHERE dl.documentType = :documentType AND dl.documentId = :documentId
+      ORDER BY dl.position
+    """
+  )
+  fun findWithProductByDocumentTypeAndDocumentId(
     documentType: DocumentLine.DocumentType,
     documentId: Long,
   ): List<DocumentLine>

--- a/src/main/kotlin/fr/axl/lvy/documentline/DocumentLineService.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/DocumentLineService.kt
@@ -12,6 +12,14 @@ class DocumentLineService(private val documentLineRepository: DocumentLineReposi
   fun findLines(documentType: DocumentLine.DocumentType, documentId: Long): List<DocumentLine> =
     documentLineRepository.findByDocumentTypeAndDocumentIdOrderByPosition(documentType, documentId)
 
+  /** Same as [findLines] but eagerly fetches the product to avoid N+1 on line.product access. */
+  @Transactional(readOnly = true)
+  fun findLinesWithProduct(
+    documentType: DocumentLine.DocumentType,
+    documentId: Long,
+  ): List<DocumentLine> =
+    documentLineRepository.findWithProductByDocumentTypeAndDocumentId(documentType, documentId)
+
   /**
    * Atomically replaces all lines of a document: deletes existing lines, then persists new ones.
    * Optionally applies a [filter] and/or overrides the VAT rate or unit price on lines.

--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
@@ -123,7 +123,7 @@ class OrderCodigService(
       if (originatingSale != null) {
         val saleId = originatingSale.id ?: return saved
         if (newStatus == OrderCodig.OrderCodigStatus.CONFIRMED) {
-          val lines = findLines(savedId)
+          val lines = findLinesWithProduct(savedId)
           if (lines.any { it.product?.isMtoProduct() == true }) {
             salesNetstoneService.createOrUpdateFromSalesCodig(
               originatingSale,
@@ -205,7 +205,7 @@ class OrderCodigService(
   @Transactional
   fun handleMto(order: OrderCodig, orderNetstoneNumber: String) {
     val lines =
-      documentLineRepository.findByDocumentTypeAndDocumentIdOrderByPosition(
+      documentLineRepository.findWithProductByDocumentTypeAndDocumentId(
         DocumentLine.DocumentType.ORDER_CODIG,
         order.id!!,
       )
@@ -247,6 +247,10 @@ class OrderCodigService(
   @Transactional(readOnly = true)
   fun findLines(orderId: Long): List<DocumentLine> =
     documentLineService.findLines(DocumentLine.DocumentType.ORDER_CODIG, orderId)
+
+  @Transactional(readOnly = true)
+  fun findLinesWithProduct(orderId: Long): List<DocumentLine> =
+    documentLineService.findLinesWithProduct(DocumentLine.DocumentType.ORDER_CODIG, orderId)
 
   /**
    * Saves the order and replaces its line items atomically. Recalculates totals and purchase price,


### PR DESCRIPTION
Adds `findWithProductByDocumentTypeAndDocumentId` on `DocumentLineRepository` with `LEFT JOIN FETCH dl.product`, plus a matching `DocumentLineService.findLinesWithProduct`.

Wired into `OrderCodigService.changeStatus` and `OrderCodigService.handleMto`, the two places that fetch lines from the DB and then iterate `line.product`. Previously triggered one SELECT per line.

Other services pass lines obtained from the UI (product already in memory) and are not affected.

Closes #8