### PR TITLE
perf: add JOIN FETCH to Invoice and DeliveryNote repositories

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteCodigRepository.kt
@@ -1,8 +1,17 @@
 package fr.axl.lvy.delivery
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface DeliveryNoteCodigRepository : JpaRepository<DeliveryNoteCodig, Long> {
+  @Query(
+    """
+      SELECT DISTINCT d FROM DeliveryNoteCodig d
+      LEFT JOIN FETCH d.orderCodig
+      LEFT JOIN FETCH d.client
+      WHERE d.deletedAt IS NULL
+    """
+  )
   fun findByDeletedAtIsNull(): List<DeliveryNoteCodig>
 
   fun findByOrderCodigIdAndDeletedAtIsNull(orderCodigId: Long): DeliveryNoteCodig?

--- a/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/DeliveryNoteNetstoneRepository.kt
@@ -1,8 +1,16 @@
 package fr.axl.lvy.delivery
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface DeliveryNoteNetstoneRepository : JpaRepository<DeliveryNoteNetstone, Long> {
+  @Query(
+    """
+      SELECT DISTINCT d FROM DeliveryNoteNetstone d
+      LEFT JOIN FETCH d.orderNetstone
+      WHERE d.deletedAt IS NULL
+    """
+  )
   fun findByDeletedAtIsNull(): List<DeliveryNoteNetstone>
 
   fun findByOrderNetstoneIdAndDeletedAtIsNull(orderNetstoneId: Long): DeliveryNoteNetstone?

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigRepository.kt
@@ -1,7 +1,18 @@
 package fr.axl.lvy.invoice
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface InvoiceCodigRepository : JpaRepository<InvoiceCodig, Long> {
+  @Query(
+    """
+      SELECT DISTINCT i FROM InvoiceCodig i
+      LEFT JOIN FETCH i.client
+      LEFT JOIN FETCH i.orderCodig
+      LEFT JOIN FETCH i.deliveryNote
+      LEFT JOIN FETCH i.creditNote
+      WHERE i.deletedAt IS NULL
+    """
+  )
   fun findByDeletedAtIsNull(): List<InvoiceCodig>
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneRepository.kt
@@ -1,7 +1,17 @@
 package fr.axl.lvy.invoice
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface InvoiceNetstoneRepository : JpaRepository<InvoiceNetstone, Long> {
+  @Query(
+    """
+      SELECT DISTINCT i FROM InvoiceNetstone i
+      LEFT JOIN FETCH i.recipient
+      LEFT JOIN FETCH i.orderNetstone
+      LEFT JOIN FETCH i.verifiedBy
+      WHERE i.deletedAt IS NULL
+    """
+  )
   fun findByDeletedAtIsNull(): List<InvoiceNetstone>
 }


### PR DESCRIPTION
Replaces derived `findByDeletedAtIsNull` queries with JPQL `LEFT JOIN FETCH` so upcoming list views can display lazy `@ManyToOne` associations without N+1 queries.

- `InvoiceCodigRepository`: client, orderCodig, deliveryNote, creditNote
- `InvoiceNetstoneRepository`: recipient, orderNetstone, verifiedBy
- `DeliveryNoteCodigRepository`: orderCodig, client
- `DeliveryNoteNetstoneRepository`: orderNetstone

Closes #12