### PR TITLE
perf: lazy-load Order and Sale ComboBoxes in Netstone dialogs

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodigRepository.kt
@@ -1,6 +1,7 @@
 package fr.axl.lvy.order
 
 import java.time.Instant
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -33,4 +34,36 @@ interface OrderCodigRepository : JpaRepository<OrderCodig, Long> {
     """
   )
   fun findDetailedById(id: Long): OrderCodig?
+
+  /**
+   * Paginated search for order pickers: matches orderNumber or client name (case-insensitive
+   * substring). Used by ComboBox lazy fetch callbacks.
+   */
+  @Query(
+    """
+      SELECT o FROM OrderCodig o
+      LEFT JOIN FETCH o.client c
+      WHERE o.deletedAt IS NULL
+        AND (
+          :filter = ''
+          OR LOWER(o.orderNumber) LIKE LOWER(CONCAT('%', :filter, '%'))
+          OR LOWER(c.name) LIKE LOWER(CONCAT('%', :filter, '%'))
+        )
+      ORDER BY o.orderNumber DESC
+    """
+  )
+  fun searchActive(@Param("filter") filter: String, pageable: Pageable): List<OrderCodig>
+
+  @Query(
+    """
+      SELECT COUNT(o) FROM OrderCodig o
+      WHERE o.deletedAt IS NULL
+        AND (
+          :filter = ''
+          OR LOWER(o.orderNumber) LIKE LOWER(CONCAT('%', :filter, '%'))
+          OR LOWER(o.client.name) LIKE LOWER(CONCAT('%', :filter, '%'))
+        )
+    """
+  )
+  fun countActive(@Param("filter") filter: String): Long
 }

--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
@@ -12,6 +12,7 @@ import java.math.BigDecimal
 import java.util.Optional
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -52,6 +53,17 @@ class OrderCodigService(
 
   @Transactional(readOnly = true)
   fun findAll(): List<OrderCodig> = orderCodigRepository.findByDeletedAtIsNull()
+
+  /** Paginated search for ComboBox lazy loading. Matches orderNumber or client name. */
+  @Transactional(readOnly = true)
+  fun search(filter: String, offset: Int, limit: Int): List<OrderCodig> =
+    orderCodigRepository.searchActive(
+      filter,
+      PageRequest.of(offset / limit.coerceAtLeast(1), limit),
+    )
+
+  @Transactional(readOnly = true)
+  fun countSearch(filter: String): Int = orderCodigRepository.countActive(filter).toInt()
 
   @Transactional(readOnly = true)
   fun findById(id: Long): Optional<OrderCodig> = orderCodigRepository.findById(id)

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
@@ -13,6 +13,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.data.provider.DataProvider
 import com.vaadin.flow.server.StreamResource
 import fr.axl.lvy.base.ui.DocumentFlowNavigation
 import fr.axl.lvy.base.ui.DocumentFlowNavigator
@@ -99,7 +100,14 @@ internal class CommandNetstoneFormDialog(
     status.setItems(visibleStatuses)
     status.setItemLabelGenerator(::statusLabel)
 
-    orderCodigCombo.setItems(orderCodigService.findAll())
+    orderCodigCombo.setItems(
+      DataProvider.fromFilteringCallbacks<OrderCodig, String>(
+        { query ->
+          orderCodigService.search(query.filter.orElse(""), query.offset, query.limit).stream()
+        },
+        { query -> orderCodigService.countSearch(query.filter.orElse("")) },
+      )
+    )
     orderCodigCombo.setItemLabelGenerator { "${it.orderNumber} - ${it.client.name}" }
     orderCodigCombo.addValueChangeListener { applyLinkedSaleDefaults() }
 

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesCodigRepository.kt
@@ -1,7 +1,9 @@
 package fr.axl.lvy.sale
 
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface SalesCodigRepository : JpaRepository<SalesCodig, Long> {
 
@@ -47,4 +49,43 @@ interface SalesCodigRepository : JpaRepository<SalesCodig, Long> {
     """
   )
   fun findByOrderCodigId(orderCodigId: Long): SalesCodig?
+
+  /**
+   * Paginated search of non-deleted sales that already have a generated Codig order. Matches by
+   * saleNumber or client name (case-insensitive). Used by ComboBox lazy fetch callbacks.
+   */
+  @Query(
+    """
+      SELECT s FROM SalesCodig s
+      LEFT JOIN FETCH s.client c
+      LEFT JOIN FETCH s.orderCodig o
+      LEFT JOIN FETCH o.client
+      WHERE s.deletedAt IS NULL
+        AND s.orderCodig IS NOT NULL
+        AND (
+          :filter = ''
+          OR LOWER(s.saleNumber) LIKE LOWER(CONCAT('%', :filter, '%'))
+          OR LOWER(c.name) LIKE LOWER(CONCAT('%', :filter, '%'))
+        )
+      ORDER BY s.saleNumber DESC
+    """
+  )
+  fun searchActiveWithLinkedOrder(
+    @Param("filter") filter: String,
+    pageable: Pageable,
+  ): List<SalesCodig>
+
+  @Query(
+    """
+      SELECT COUNT(s) FROM SalesCodig s
+      WHERE s.deletedAt IS NULL
+        AND s.orderCodig IS NOT NULL
+        AND (
+          :filter = ''
+          OR LOWER(s.saleNumber) LIKE LOWER(CONCAT('%', :filter, '%'))
+          OR LOWER(s.client.name) LIKE LOWER(CONCAT('%', :filter, '%'))
+        )
+    """
+  )
+  fun countActiveWithLinkedOrder(@Param("filter") filter: String): Long
 }

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
@@ -11,6 +11,7 @@ import java.math.BigDecimal
 import java.util.Optional
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -40,6 +41,18 @@ class SalesCodigService(
   @Transactional(readOnly = true)
   fun findAllWithLinkedOrder(): List<SalesCodig> =
     salesCodigRepository.findByDeletedAtIsNullAndOrderCodigIsNotNull()
+
+  /** Paginated search of sales that have a generated Codig order. For ComboBox lazy loading. */
+  @Transactional(readOnly = true)
+  fun searchWithLinkedOrder(filter: String, offset: Int, limit: Int): List<SalesCodig> =
+    salesCodigRepository.searchActiveWithLinkedOrder(
+      filter,
+      PageRequest.of(offset / limit.coerceAtLeast(1), limit),
+    )
+
+  @Transactional(readOnly = true)
+  fun countSearchWithLinkedOrder(filter: String): Int =
+    salesCodigRepository.countActiveWithLinkedOrder(filter).toInt()
 
   @Transactional(readOnly = true)
   fun findById(id: Long): Optional<SalesCodig> = salesCodigRepository.findById(id)

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
@@ -12,6 +12,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.data.provider.DataProvider
 import fr.axl.lvy.base.ui.DocumentFlowNavigation
 import fr.axl.lvy.base.ui.DocumentFlowNavigator
 import fr.axl.lvy.base.ui.DocumentFlowStep
@@ -85,7 +86,16 @@ internal class SalesNetstoneFormDialog(
     fiscalPositionCombo.setItemLabelGenerator { it.position }
     deliveryAddressCombo.setItemLabelGenerator { it.label }
 
-    orderCodigCombo.setItems(salesCodigService.findAllWithLinkedOrder())
+    orderCodigCombo.setItems(
+      DataProvider.fromFilteringCallbacks<SalesCodig, String>(
+        { query ->
+          salesCodigService
+            .searchWithLinkedOrder(query.filter.orElse(""), query.offset, query.limit)
+            .stream()
+        },
+        { query -> salesCodigService.countSearchWithLinkedOrder(query.filter.orElse("")) },
+      )
+    )
     orderCodigCombo.setItemLabelGenerator {
       val linkedOrder = it.orderCodig
       if (linkedOrder == null) {

--- a/src/test/kotlin/fr/axl/lvy/order/OrderCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/order/OrderCodigServiceTest.kt
@@ -540,4 +540,44 @@ class OrderCodigServiceTest {
     assertThat(lines).hasSize(1)
     assertThat(lines[0].designation).isEqualTo("Widget B")
   }
+
+  @Test
+  fun search_matches_orderNumber_case_insensitive() {
+    val client = testData.createClient("CLI-OA-SRCH-1")
+    val a = OrderCodig("CA-SRCH-ALPHA", client, LocalDate.of(2026, 3, 1))
+    val b = OrderCodig("CA-SRCH-BETA", client, LocalDate.of(2026, 3, 1))
+    orderCodigRepository.saveAllAndFlush(listOf(a, b))
+
+    val byAlpha = orderCodigService.search("alpha", 0, 20).map { it.orderNumber }
+    assertThat(byAlpha).contains("CA-SRCH-ALPHA").doesNotContain("CA-SRCH-BETA")
+
+    assertThat(orderCodigService.countSearch("alpha")).isEqualTo(1)
+  }
+
+  @Test
+  fun search_matches_client_name_and_paginates() {
+    val client = testData.createClient("CLI-OA-SRCH-2")
+    client.name = "Acme Widgets SA"
+    clientService.save(client)
+    repeat(3) { index ->
+      orderCodigRepository.save(OrderCodig("CA-PAGE-$index", client, LocalDate.of(2026, 3, 1)))
+    }
+    orderCodigRepository.flush()
+
+    val page1 = orderCodigService.search("acme", 0, 2)
+    val page2 = orderCodigService.search("acme", 2, 2)
+    assertThat(page1).hasSize(2)
+    assertThat(page2).hasSize(1)
+    assertThat(orderCodigService.countSearch("acme")).isEqualTo(3)
+  }
+
+  @Test
+  fun search_with_empty_filter_returns_all_active_orders() {
+    val client = testData.createClient("CLI-OA-SRCH-3")
+    val created = orderCodigRepository.save(OrderCodig("CA-EMPTY-FILTER", client, LocalDate.now()))
+    orderCodigRepository.flush()
+
+    val numbers = orderCodigService.search("", 0, 100).map { it.orderNumber }
+    assertThat(numbers).contains(created.orderNumber)
+  }
 }

--- a/src/test/kotlin/fr/axl/lvy/sale/SalesCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/sale/SalesCodigServiceTest.kt
@@ -530,6 +530,56 @@ class SalesCodigServiceTest {
   }
 
   @Test
+  fun searchWithLinkedOrder_matches_saleNumber_and_counts() {
+    val client = testData.createClient("CLI-SA-SRCH-1")
+    val withOrder = createSalesCodig("SA-SRCH-GAMMA", client)
+    createSalesCodig("SA-SRCH-DELTA", client) // standalone sale, no order
+    val mtoProduct = testData.createMtoProduct("PRD-SA-SRCH-1")
+    val line =
+      testData.createDocumentLine(
+        DocumentLine.DocumentType.SALES_CODIG,
+        withOrder.id!!,
+        "Widget",
+        product = mtoProduct,
+      )
+    salesCodigService.syncGeneratedOrder(withOrder, listOf(line))
+    salesCodigRepository.flush()
+
+    val byGamma = salesCodigService.searchWithLinkedOrder("gamma", 0, 10).map { it.saleNumber }
+    assertThat(byGamma).contains("SA-SRCH-GAMMA").doesNotContain("SA-SRCH-DELTA")
+
+    assertThat(salesCodigService.countSearchWithLinkedOrder("gamma")).isEqualTo(1)
+    // Standalone sale without order must not be counted even with empty filter.
+    assertThat(salesCodigService.countSearchWithLinkedOrder("SA-SRCH-DELTA")).isEqualTo(0)
+  }
+
+  @Test
+  fun searchWithLinkedOrder_matches_client_name_and_paginates() {
+    val client = testData.createClient("CLI-SA-SRCH-2")
+    client.name = "Globex Corp"
+    clientService.save(client)
+    val mtoProduct = testData.createMtoProduct("PRD-SA-SRCH-2")
+    repeat(3) { index ->
+      val sale = createSalesCodig("SA-SRCH-PAGE-$index", client)
+      val line =
+        testData.createDocumentLine(
+          DocumentLine.DocumentType.SALES_CODIG,
+          sale.id!!,
+          "Widget",
+          product = mtoProduct,
+        )
+      salesCodigService.syncGeneratedOrder(sale, listOf(line))
+    }
+    salesCodigRepository.flush()
+
+    val page1 = salesCodigService.searchWithLinkedOrder("globex", 0, 2)
+    val page2 = salesCodigService.searchWithLinkedOrder("globex", 2, 2)
+    assertThat(page1).hasSize(2)
+    assertThat(page2).hasSize(1)
+    assertThat(salesCodigService.countSearchWithLinkedOrder("globex")).isEqualTo(3)
+  }
+
+  @Test
   fun findAllWithLinkedOrder_includes_only_sales_with_orderCodig() {
     val client = testData.createClient("CLI-SA-LNK")
     val linked = createSalesCodig("SA-LNK-01", client)


### PR DESCRIPTION
`CommandNetstoneFormDialog` and `SalesNetstoneFormDialog` previously loaded the full `OrderCodig` / `SalesCodig` tables into their linked-order ComboBoxes. Switches to Vaadin's `BackEndDataProvider` backed by paginated repository searches on `orderNumber` / `saleNumber` and client name (case-insensitive).

New APIs:
- `OrderCodigRepository.searchActive` / `countActive`
- `SalesCodigRepository.searchActiveWithLinkedOrder` / `countActiveWithLinkedOrder`
- `OrderCodigService.search` / `countSearch`
- `SalesCodigService.searchWithLinkedOrder` / `countSearchWithLinkedOrder`

Closes #10