### PR TITLE
fix(sale): freeze generated order after first creation

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
@@ -85,24 +85,23 @@ class SalesCodigService(
   }
 
   /**
-   * Synchronizes the auto-generated [OrderCodig] from this sale. Once the order has progressed past
-   * DRAFT the sale can no longer mutate it (fields, lines, or existence) — it is then an
-   * independent document. If no MTO products remain and the order is still DRAFT, the linked order
-   * and Netstone sale are deleted. Otherwise, the order is created/updated with the sale's fields
-   * and line items.
+   * Generates the auto-created [OrderCodig] from this sale, once. Runs only when the sale has no
+   * linked order yet and contains at least one MTO product line. Once the order exists, further
+   * sale edits do not alter it — the order becomes an independent document.
+   *
+   * This one-shot rule (issue #32) prevents routine sale modifications from silently overwriting
+   * order fields that a user or the procurement workflow may have since changed.
    */
   @Transactional
   fun syncGeneratedOrder(sale: SalesCodig, saleLines: List<DocumentLine>): SalesCodig {
-    val existingOrder = sale.orderCodig
-    if (existingOrder != null && existingOrder.status != OrderCodig.OrderCodigStatus.DRAFT) {
+    if (sale.orderCodig != null) {
+      // Order already generated: automation disabled, do not mutate the linked order.
       return sale
     }
 
     if (saleLines.none { it.product?.isMtoProduct() == true }) {
-      existingOrder?.id?.let { orderCodigService.delete(it) }
-      sale.id?.let { salesNetstoneService.deleteBySalesCodigId(it) }
-      sale.orderCodig = null
-      return salesCodigRepository.save(sale)
+      // No MTO line, nothing to generate.
+      return sale
     }
 
     val supplier =
@@ -111,9 +110,8 @@ class SalesCodigService(
           "Aucun fournisseur Netstone par defaut n'est configure dans les societes internes"
         )
       }
-    val order = sale.orderCodig ?: OrderCodig("", supplier, sale.saleDate)
+    val order = OrderCodig("", supplier, sale.saleDate)
     val codigCompany = clientService.findDefaultCodigCompany().orElse(null)
-    val isNewOrder = sale.orderCodig == null
 
     order.client = supplier
     order.orderDate = sale.saleDate
@@ -132,9 +130,7 @@ class SalesCodigService(
     order.shippingAddress = sale.shippingAddress
     order.notes = sale.notes
     order.conditions = sale.conditions
-    if (sale.orderCodig == null) {
-      order.status = OrderCodig.OrderCodigStatus.DRAFT
-    }
+    order.status = OrderCodig.OrderCodigStatus.DRAFT
 
     val savedOrder = orderCodigService.save(order)
     val generatedLines =
@@ -153,11 +149,7 @@ class SalesCodigService(
     MDC.put("saleNumber", sale.saleNumber)
     MDC.put("orderNumber", savedOrder.orderNumber)
     try {
-      if (isNewOrder) {
-        log.info("SalesCodig {} generated OrderCodig {}", sale.saleNumber, savedOrder.orderNumber)
-      } else {
-        log.info("SalesCodig {} synced OrderCodig {}", sale.saleNumber, savedOrder.orderNumber)
-      }
+      log.info("SalesCodig {} generated OrderCodig {}", sale.saleNumber, savedOrder.orderNumber)
     } finally {
       MDC.remove("saleNumber")
       MDC.remove("orderNumber")

--- a/src/test/kotlin/fr/axl/lvy/sale/SalesCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/sale/SalesCodigServiceTest.kt
@@ -210,7 +210,7 @@ class SalesCodigServiceTest {
   }
 
   @Test
-  fun syncGeneratedOrder_updates_existing_order() {
+  fun syncGeneratedOrder_does_not_overwrite_existing_order() {
     val client = testData.createClient("CLI-SA05")
     val sale = createSalesCodig("SA-SYNC-02", client)
     salesCodigRepository.flush()
@@ -227,6 +227,10 @@ class SalesCodigServiceTest {
 
     salesCodigService.syncGeneratedOrder(sale, listOf(line1))
     val firstOrderId = sale.orderCodig!!.id!!
+    // Capture field that later "sale" modifications would try to overwrite.
+    val originalNotes = "locked by procurement"
+    sale.orderCodig!!.notes = originalNotes
+    orderCodigRepository.saveAndFlush(sale.orderCodig!!)
 
     val line2 =
       testData.createDocumentLine(
@@ -235,10 +239,15 @@ class SalesCodigServiceTest {
         "Widget B",
         product = mtoProduct,
       )
+    sale.notes = "changed on sale"
 
     salesCodigService.syncGeneratedOrder(sale, listOf(line2))
 
+    // Order reference unchanged.
     assertThat(sale.orderCodig!!.id).isEqualTo(firstOrderId)
+    // Per issue #32, the sale's later edits must not overwrite the generated order.
+    val reloaded = orderCodigRepository.findById(firstOrderId).orElseThrow()
+    assertThat(reloaded.notes).isEqualTo(originalNotes)
   }
 
   @Test


### PR DESCRIPTION
`SalesCodigService.syncGeneratedOrder` used to re-run on every sale save, overwriting the linked `OrderCodig` fields and line items whenever the order was still in `DRAFT` — and deleting it entirely if the sale lost its MTO lines.

Now the sync is a one-shot generator: it creates the `OrderCodig` the first time a sale is saved with at least one MTO line, then never touches the generated order again. Subsequent sale edits no longer propagate to the order, so procurement-side changes are preserved.

Adds a regression test `syncGeneratedOrder_does_not_overwrite_existing_order` that pokes a field on the generated order and verifies later sale saves do not wipe it.

Closes #32