### PR TITLE
feat: feat(pdf): Factures CoDIG/Netstone: formulaires, PDF et statuts

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/base/NumberSequence.kt
+++ b/src/main/kotlin/fr/axl/lvy/base/NumberSequence.kt
@@ -12,6 +12,6 @@ import jakarta.persistence.Table
 @Entity
 @Table(name = "number_sequences")
 class NumberSequence(
-  @Id @Column(name = "entity_type", length = 20) val entityType: String,
+  @Id @Column(name = "entity_type", length = 32) val entityType: String,
   @Column(name = "next_val", nullable = false) var nextVal: Long = 1,
 )

--- a/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
+++ b/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
@@ -34,6 +34,12 @@ class NumberSequenceService(
     return config.prefix + current.toString().padStart(config.padding, '0')
   }
 
+  @Transactional(readOnly = true)
+  fun previewNextNumber(entityType: String, prefix: String, padding: Int): String {
+    val current = repository.findById(entityType).map { it.nextVal }.orElse(1)
+    return prefix + current.toString().padStart(padding, '0')
+  }
+
   @Transactional
   fun nextNumber(entityType: String, prefix: String, padding: Int): String {
     val seq = repository.findForUpdate(entityType) ?: repository.save(NumberSequence(entityType))
@@ -54,6 +60,8 @@ class NumberSequenceService(
     const val SALES_NETSTONE = "SALES_NETSTONE"
     const val DELIVERY_CODIG = "DELIVERY_CODIG"
     const val DELIVERY_NETSTONE = "DELIVERY_NETSTONE"
+    const val INVOICE_CODIG = "INVOICE_CODIG"
+    const val INVOICE_NETSTONE = "INVOICE_NETSTONE"
 
     val CONFIGS =
       mapOf(
@@ -64,6 +72,8 @@ class NumberSequenceService(
         SALES_NETSTONE to SequenceConfig("NST_SO_", 3),
         DELIVERY_CODIG to SequenceConfig("CoD/OUT/", 3),
         DELIVERY_NETSTONE to SequenceConfig("Netst/OUT/", 3),
+        INVOICE_CODIG to SequenceConfig("CoD/INV/", 3),
+        INVOICE_NETSTONE to SequenceConfig("NST/INV/", 3),
       )
   }
 }

--- a/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
+++ b/src/main/kotlin/fr/axl/lvy/base/NumberSequenceService.kt
@@ -40,6 +40,20 @@ class NumberSequenceService(
     return prefix + current.toString().padStart(padding, '0')
   }
 
+  /**
+   * Year-scoped preview: derives prefix and padding from [CONFIGS] for [baseEntityType] and appends
+   * the year, so the counter resets every year (e.g. INVOICE_CODIG_2026 -> "CoD_INV/2026/001").
+   */
+  @Transactional(readOnly = true)
+  fun previewNextNumberForYear(baseEntityType: String, year: Int): String {
+    val config =
+      CONFIGS[baseEntityType]
+        ?: throw IllegalArgumentException("Unknown entity type: $baseEntityType")
+    val key = "${baseEntityType}_$year"
+    val current = repository.findById(key).map { it.nextVal }.orElse(1)
+    return "${config.prefix}$year/" + current.toString().padStart(config.padding, '0')
+  }
+
   @Transactional
   fun nextNumber(entityType: String, prefix: String, padding: Int): String {
     val seq = repository.findForUpdate(entityType) ?: repository.save(NumberSequence(entityType))
@@ -48,6 +62,16 @@ class NumberSequenceService(
     repository.save(seq)
     meterRegistry.counter("number.sequence.generated", "type", entityType).increment()
     return prefix + current.toString().padStart(padding, '0')
+  }
+
+  /** Year-scoped allocation that mirrors [previewNextNumberForYear] but locks and increments. */
+  @Transactional
+  fun nextNumberForYear(baseEntityType: String, year: Int): String {
+    val config =
+      CONFIGS[baseEntityType]
+        ?: throw IllegalArgumentException("Unknown entity type: $baseEntityType")
+    val key = "${baseEntityType}_$year"
+    return nextNumber(key, "${config.prefix}$year/", config.padding)
   }
 
   data class SequenceConfig(val prefix: String, val padding: Int)
@@ -72,8 +96,8 @@ class NumberSequenceService(
         SALES_NETSTONE to SequenceConfig("NST_SO_", 3),
         DELIVERY_CODIG to SequenceConfig("CoD/OUT/", 3),
         DELIVERY_NETSTONE to SequenceConfig("Netst/OUT/", 3),
-        INVOICE_CODIG to SequenceConfig("CoD/INV/", 3),
-        INVOICE_NETSTONE to SequenceConfig("NST/INV/", 3),
+        INVOICE_CODIG to SequenceConfig("CoD_INV/", 3),
+        INVOICE_NETSTONE to SequenceConfig("NST_INV/", 3),
       )
   }
 }

--- a/src/main/kotlin/fr/axl/lvy/documentline/ui/DocumentLineEditor.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/ui/DocumentLineEditor.kt
@@ -28,6 +28,7 @@ class DocumentLineEditor(
   private val clientSupplier: (() -> Client?)? = null,
   private val currencySupplier: (() -> String?)? = null,
   private val currencyUpdater: ((String) -> Unit)? = null,
+  private val unitPriceOverrideProvider: ((Product) -> BigDecimal?)? = null,
   private val usePurchasePrice: Boolean = false,
   private val lineTaxMode: LineTaxMode = LineTaxMode.DISCOUNT,
   private val defaultVatRate: BigDecimal = BigDecimal.ZERO,
@@ -214,6 +215,7 @@ class DocumentLineEditor(
     currencyUpdater?.invoke(
       if (usePurchasePrice) product.purchaseCurrency else product.sellingCurrency
     )
+    unitPriceOverrideProvider?.invoke(product)?.let { line.unitPriceExclTax = it }
     if (lineTaxMode == LineTaxMode.VAT) {
       line.vatRate = defaultVatRate
     }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodig.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodig.kt
@@ -3,6 +3,7 @@ package fr.axl.lvy.invoice
 import fr.axl.lvy.base.SoftDeletableEntity
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.delivery.DeliveryNoteCodig
+import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.order.OrderCodig
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotBlank
@@ -85,6 +86,14 @@ class InvoiceCodig(
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "credit_note_id")
   var creditNote: InvoiceCodig? = null
+
+  /** Recomputes invoice totals from the current set of persisted invoice lines. */
+  fun recalculateTotals(lines: List<DocumentLine>) {
+    val totals = DocumentLine.computeTotals(lines)
+    totalExclTax = totals.exclTax
+    totalVat = totals.vat
+    totalInclTax = totals.inclTax
+  }
 
   enum class InvoiceCodigStatus {
     DRAFT,

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigRepository.kt
@@ -15,4 +15,29 @@ interface InvoiceCodigRepository : JpaRepository<InvoiceCodig, Long> {
     """
   )
   fun findByDeletedAtIsNull(): List<InvoiceCodig>
+
+  @Query(
+    """
+      SELECT i FROM InvoiceCodig i
+      LEFT JOIN FETCH i.client
+      LEFT JOIN FETCH i.orderCodig
+      LEFT JOIN FETCH i.deliveryNote
+      LEFT JOIN FETCH i.creditNote
+      WHERE i.id = :id
+    """
+  )
+  fun findDetailedById(id: Long): InvoiceCodig?
+
+  @Query(
+    """
+      SELECT i FROM InvoiceCodig i
+      LEFT JOIN FETCH i.client
+      LEFT JOIN FETCH i.orderCodig
+      LEFT JOIN FETCH i.deliveryNote
+      LEFT JOIN FETCH i.creditNote
+      WHERE i.orderCodig.id = :orderCodigId
+        AND i.deletedAt IS NULL
+    """
+  )
+  fun findDetailedByOrderCodigId(orderCodigId: Long): InvoiceCodig?
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigRepository.kt
@@ -37,7 +37,11 @@ interface InvoiceCodigRepository : JpaRepository<InvoiceCodig, Long> {
       LEFT JOIN FETCH i.creditNote
       WHERE i.orderCodig.id = :orderCodigId
         AND i.deletedAt IS NULL
+      ORDER BY i.id DESC
     """
   )
-  fun findDetailedByOrderCodigId(orderCodigId: Long): InvoiceCodig?
+  fun findDetailedByOrderCodigIdOrdered(orderCodigId: Long): List<InvoiceCodig>
+
+  fun findDetailedByOrderCodigId(orderCodigId: Long): InvoiceCodig? =
+    findDetailedByOrderCodigIdOrdered(orderCodigId).firstOrNull()
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigService.kt
@@ -46,7 +46,10 @@ class InvoiceCodigService(
   /** Returns the preview number shown before a Codig invoice is first saved. */
   @Transactional(readOnly = true)
   fun previewNextInvoiceNumber(invoiceDate: LocalDate): String =
-    numberSequenceService.previewNextNumber(sequenceKey(invoiceDate), previewPrefix(invoiceDate), 3)
+    numberSequenceService.previewNextNumberForYear(
+      NumberSequenceService.INVOICE_CODIG,
+      invoiceDate.year,
+    )
 
   /** Prepares an existing invoice or a prefilled draft invoice for the given Codig sale. */
   @Transactional(readOnly = true)
@@ -72,12 +75,14 @@ class InvoiceCodigService(
   fun saveWithLines(invoice: InvoiceCodig, lines: List<DocumentLine>): InvoiceCodig {
     val isNew = invoice.invoiceNumber.isBlank()
     if (isNew) {
-      val invoiceDate = invoice.invoiceDate
       invoice.invoiceNumber =
-        numberSequenceService.nextNumber(sequenceKey(invoiceDate), previewPrefix(invoiceDate), 3)
+        numberSequenceService.nextNumberForYear(
+          NumberSequenceService.INVOICE_CODIG,
+          invoice.invoiceDate.year,
+        )
     }
     if (invoice.orderCodig == null) {
-      error("La facture CoDIG doit etre rattachee a une commande CoDIG")
+      error("La facture CoDIG doit être rattachée à une commande CoDIG")
     }
     if (invoice.clientName.isNullOrBlank()) {
       invoice.clientName = invoice.client.name
@@ -105,7 +110,11 @@ class InvoiceCodigService(
     if (order.invoice?.id != persistedInvoice.id) {
       order.invoice = persistedInvoice
     }
-    if (order.status != OrderCodig.OrderCodigStatus.INVOICED) {
+    // Only advance the order to INVOICED once the invoice leaves the DRAFT state.
+    if (
+      persistedInvoice.status != InvoiceCodig.InvoiceCodigStatus.DRAFT &&
+        order.status != OrderCodig.OrderCodigStatus.INVOICED
+    ) {
       order.status = OrderCodig.OrderCodigStatus.INVOICED
     }
     orderCodigRepository.save(order)
@@ -120,9 +129,4 @@ class InvoiceCodigService(
     }
     return persistedInvoice
   }
-
-  private fun sequenceKey(invoiceDate: LocalDate): String =
-    "${NumberSequenceService.INVOICE_CODIG}_${invoiceDate.year}"
-
-  private fun previewPrefix(invoiceDate: LocalDate): String = "CoD_INV/${invoiceDate.year}/"
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceCodigService.kt
@@ -1,0 +1,128 @@
+package fr.axl.lvy.invoice
+
+import fr.axl.lvy.base.NumberSequenceService
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.DocumentLineService
+import fr.axl.lvy.order.OrderCodig
+import fr.axl.lvy.order.OrderCodigRepository
+import fr.axl.lvy.sale.SalesCodig
+import io.micrometer.core.instrument.MeterRegistry
+import java.time.LocalDate
+import java.util.Optional
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/** Manages Codig invoices created from customer orders and their invoice lines. */
+@Service
+class InvoiceCodigService(
+  private val invoiceCodigRepository: InvoiceCodigRepository,
+  private val orderCodigRepository: OrderCodigRepository,
+  private val documentLineService: DocumentLineService,
+  private val numberSequenceService: NumberSequenceService,
+  meterRegistry: MeterRegistry,
+) {
+  private val invoicesCreatedCounter = meterRegistry.counter("invoice.codig")
+
+  companion object {
+    private val log = LoggerFactory.getLogger(InvoiceCodigService::class.java)
+  }
+
+  /** Returns the active invoice already linked to the given Codig order, if any. */
+  @Transactional(readOnly = true)
+  fun findByOrderCodigId(orderCodigId: Long): InvoiceCodig? =
+    invoiceCodigRepository.findDetailedByOrderCodigId(orderCodigId)
+
+  /** Loads the invoice lines persisted for the given invoice. */
+  @Transactional(readOnly = true)
+  fun findLines(invoiceId: Long): List<DocumentLine> =
+    documentLineService.findLines(DocumentLine.DocumentType.INVOICE_CODIG, invoiceId)
+
+  /** Loads a single invoice by id. */
+  @Transactional(readOnly = true)
+  fun findById(id: Long): Optional<InvoiceCodig> =
+    Optional.ofNullable(invoiceCodigRepository.findDetailedById(id))
+
+  /** Returns the preview number shown before a Codig invoice is first saved. */
+  @Transactional(readOnly = true)
+  fun previewNextInvoiceNumber(invoiceDate: LocalDate): String =
+    numberSequenceService.previewNextNumber(sequenceKey(invoiceDate), previewPrefix(invoiceDate), 3)
+
+  /** Prepares an existing invoice or a prefilled draft invoice for the given Codig sale. */
+  @Transactional(readOnly = true)
+  fun prepareForSale(sale: SalesCodig, order: OrderCodig): InvoiceCodig =
+    order.id?.let(::findByOrderCodigId)
+      ?: order.invoice
+      ?: InvoiceCodig("", sale.client, sale.saleDate).apply {
+        orderCodig = order
+        deliveryNote = order.deliveryNote
+        client = sale.client
+        clientName = sale.client.name
+        clientAddress = sale.billingAddress ?: sale.client.billingAddress
+        clientSiret = sale.client.siret
+        clientVatNumber = sale.client.vatNumber
+        dueDate = sale.expectedDeliveryDate
+        currency = sale.currency
+        incoterms = sale.incoterms
+        notes = sale.notes
+      }
+
+  /** Saves the invoice and replaces its lines from the current editor content. */
+  @Transactional
+  fun saveWithLines(invoice: InvoiceCodig, lines: List<DocumentLine>): InvoiceCodig {
+    val isNew = invoice.invoiceNumber.isBlank()
+    if (isNew) {
+      val invoiceDate = invoice.invoiceDate
+      invoice.invoiceNumber =
+        numberSequenceService.nextNumber(sequenceKey(invoiceDate), previewPrefix(invoiceDate), 3)
+    }
+    if (invoice.orderCodig == null) {
+      error("La facture CoDIG doit etre rattachee a une commande CoDIG")
+    }
+    if (invoice.clientName.isNullOrBlank()) {
+      invoice.clientName = invoice.client.name
+    }
+    if (invoice.clientAddress.isNullOrBlank()) {
+      invoice.clientAddress = invoice.orderCodig?.billingAddress ?: invoice.client.billingAddress
+    }
+    if (invoice.clientSiret.isNullOrBlank()) {
+      invoice.clientSiret = invoice.client.siret
+    }
+    if (invoice.clientVatNumber.isNullOrBlank()) {
+      invoice.clientVatNumber = invoice.client.vatNumber
+    }
+    if (invoice.deliveryNote == null) {
+      invoice.deliveryNote = invoice.orderCodig?.deliveryNote
+    }
+
+    val saved = invoiceCodigRepository.save(invoice)
+    val persistedLines =
+      documentLineService.replaceLines(DocumentLine.DocumentType.INVOICE_CODIG, saved.id!!, lines)
+    saved.recalculateTotals(persistedLines)
+    val persistedInvoice = invoiceCodigRepository.save(saved)
+
+    val order = persistedInvoice.orderCodig ?: error("Commande CoDIG introuvable")
+    if (order.invoice?.id != persistedInvoice.id) {
+      order.invoice = persistedInvoice
+    }
+    if (order.status != OrderCodig.OrderCodigStatus.INVOICED) {
+      order.status = OrderCodig.OrderCodigStatus.INVOICED
+    }
+    orderCodigRepository.save(order)
+
+    if (isNew) {
+      invoicesCreatedCounter.increment()
+      log.info(
+        "InvoiceCodig created: number={} order={}",
+        persistedInvoice.invoiceNumber,
+        order.orderNumber,
+      )
+    }
+    return persistedInvoice
+  }
+
+  private fun sequenceKey(invoiceDate: LocalDate): String =
+    "${NumberSequenceService.INVOICE_CODIG}_${invoiceDate.year}"
+
+  private fun previewPrefix(invoiceDate: LocalDate): String = "CoD_INV/${invoiceDate.year}/"
+}

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstone.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstone.kt
@@ -2,6 +2,7 @@ package fr.axl.lvy.invoice
 
 import fr.axl.lvy.base.SoftDeletableEntity
 import fr.axl.lvy.client.Client
+import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.user.User
 import jakarta.persistence.*
@@ -37,6 +38,8 @@ class InvoiceNetstone(
   var recipient: Client,
   @Column(name = "invoice_date", nullable = false) var invoiceDate: LocalDate,
 ) : SoftDeletableEntity() {
+  @Column(name = "billing_address", columnDefinition = "TEXT") var billingAddress: String? = null
+
   @Column(name = "supplier_invoice_number", length = 50) var supplierInvoiceNumber: String? = null
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -82,6 +85,14 @@ class InvoiceNetstone(
   @Column(name = "pdf_path", length = 500) var pdfPath: String? = null
 
   @Column(columnDefinition = "TEXT") var notes: String? = null
+
+  /** Recomputes invoice totals from the current set of persisted invoice lines. */
+  fun recalculateTotals(lines: List<DocumentLine>) {
+    val totals = DocumentLine.computeTotals(lines)
+    totalExclTax = totals.exclTax
+    totalVat = totals.vat
+    totalInclTax = totals.inclTax
+  }
 
   enum class RecipientType {
     /** Invoice billed to Codig (inter-company). */

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneRepository.kt
@@ -36,7 +36,11 @@ interface InvoiceNetstoneRepository : JpaRepository<InvoiceNetstone, Long> {
       LEFT JOIN FETCH i.verifiedBy
       WHERE i.orderNetstone.id = :orderNetstoneId
         AND i.deletedAt IS NULL
+      ORDER BY i.id DESC
     """
   )
-  fun findDetailedByOrderNetstoneId(orderNetstoneId: Long): InvoiceNetstone?
+  fun findDetailedByOrderNetstoneIdOrdered(orderNetstoneId: Long): List<InvoiceNetstone>
+
+  fun findDetailedByOrderNetstoneId(orderNetstoneId: Long): InvoiceNetstone? =
+    findDetailedByOrderNetstoneIdOrdered(orderNetstoneId).firstOrNull()
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneRepository.kt
@@ -14,4 +14,29 @@ interface InvoiceNetstoneRepository : JpaRepository<InvoiceNetstone, Long> {
     """
   )
   fun findByDeletedAtIsNull(): List<InvoiceNetstone>
+
+  @Query(
+    """
+      SELECT i FROM InvoiceNetstone i
+      LEFT JOIN FETCH i.recipient
+      LEFT JOIN FETCH i.orderNetstone o
+      LEFT JOIN FETCH o.orderCodig
+      LEFT JOIN FETCH i.verifiedBy
+      WHERE i.id = :id
+    """
+  )
+  fun findDetailedById(id: Long): InvoiceNetstone?
+
+  @Query(
+    """
+      SELECT i FROM InvoiceNetstone i
+      LEFT JOIN FETCH i.recipient
+      LEFT JOIN FETCH i.orderNetstone o
+      LEFT JOIN FETCH o.orderCodig
+      LEFT JOIN FETCH i.verifiedBy
+      WHERE i.orderNetstone.id = :orderNetstoneId
+        AND i.deletedAt IS NULL
+    """
+  )
+  fun findDetailedByOrderNetstoneId(orderNetstoneId: Long): InvoiceNetstone?
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneService.kt
@@ -48,7 +48,10 @@ class InvoiceNetstoneService(
   /** Returns the preview number shown before a Netstone invoice is first saved. */
   @Transactional(readOnly = true)
   fun previewNextInvoiceNumber(invoiceDate: LocalDate): String =
-    numberSequenceService.previewNextNumber(sequenceKey(invoiceDate), previewPrefix(invoiceDate), 3)
+    numberSequenceService.previewNextNumberForYear(
+      NumberSequenceService.INVOICE_NETSTONE,
+      invoiceDate.year,
+    )
 
   /** Prepares an existing invoice or a prefilled draft invoice for the given Netstone sale. */
   @Transactional(readOnly = true)
@@ -60,7 +63,7 @@ class InvoiceNetstoneService(
   private fun createDraftInvoice(sale: SalesNetstone, order: OrderNetstone): InvoiceNetstone {
     val codig =
       clientService.findDefaultCodigCompany().orElseThrow {
-        IllegalStateException("Aucune societe Codig n'est configuree")
+        IllegalStateException("Aucune société Codig n'est configurée")
       }
     return InvoiceNetstone(
         "",
@@ -84,20 +87,19 @@ class InvoiceNetstoneService(
     val isNew = invoice.internalInvoiceNumber.isBlank()
     if (isNew) {
       invoice.internalInvoiceNumber =
-        numberSequenceService.nextNumber(
-          sequenceKey(invoice.invoiceDate),
-          previewPrefix(invoice.invoiceDate),
-          3,
+        numberSequenceService.nextNumberForYear(
+          NumberSequenceService.INVOICE_NETSTONE,
+          invoice.invoiceDate.year,
         )
     }
     if (invoice.orderNetstone == null) {
-      error("La facture Netstone doit etre rattachee a une commande Netstone")
+      error("La facture Netstone doit être rattachée à une commande Netstone")
     }
     invoice.origin = InvoiceNetstone.Origin.ORDER_LINKED
     if (invoice.recipientType == InvoiceNetstone.RecipientType.COMPANY_CODIG) {
       val codig =
         clientService.findDefaultCodigCompany().orElseThrow {
-          IllegalStateException("Aucune societe Codig n'est configuree")
+          IllegalStateException("Aucune société Codig n'est configurée")
         }
       invoice.recipient = codig
       if (invoice.billingAddress.isNullOrBlank()) {
@@ -131,9 +133,4 @@ class InvoiceNetstoneService(
     }
     return persistedInvoice
   }
-
-  private fun sequenceKey(invoiceDate: LocalDate): String =
-    "${NumberSequenceService.INVOICE_NETSTONE}_${invoiceDate.year}"
-
-  private fun previewPrefix(invoiceDate: LocalDate): String = "NST_INV/${invoiceDate.year}/"
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneService.kt
@@ -107,7 +107,11 @@ class InvoiceNetstoneService(
 
     val saved = invoiceNetstoneRepository.save(invoice)
     val persistedLines =
-      documentLineService.replaceLines(DocumentLine.DocumentType.INVOICE_NETSTONE, saved.id!!, lines)
+      documentLineService.replaceLines(
+        DocumentLine.DocumentType.INVOICE_NETSTONE,
+        saved.id!!,
+        lines,
+      )
     saved.recalculateTotals(persistedLines)
     val persistedInvoice = invoiceNetstoneRepository.save(saved)
 

--- a/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneService.kt
@@ -1,0 +1,135 @@
+package fr.axl.lvy.invoice
+
+import fr.axl.lvy.base.NumberSequenceService
+import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.DocumentLineService
+import fr.axl.lvy.order.OrderNetstone
+import fr.axl.lvy.order.OrderNetstoneRepository
+import fr.axl.lvy.sale.SalesNetstone
+import io.micrometer.core.instrument.MeterRegistry
+import java.time.LocalDate
+import java.util.Optional
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/** Manages Netstone supplier invoices linked to procurement orders and their lines. */
+@Service
+class InvoiceNetstoneService(
+  private val invoiceNetstoneRepository: InvoiceNetstoneRepository,
+  private val orderNetstoneRepository: OrderNetstoneRepository,
+  private val documentLineService: DocumentLineService,
+  private val numberSequenceService: NumberSequenceService,
+  private val clientService: ClientService,
+  meterRegistry: MeterRegistry,
+) {
+  private val invoicesCreatedCounter = meterRegistry.counter("invoice.netstone")
+
+  companion object {
+    private val log = LoggerFactory.getLogger(InvoiceNetstoneService::class.java)
+  }
+
+  /** Returns the active invoice already linked to the given Netstone order, if any. */
+  @Transactional(readOnly = true)
+  fun findByOrderNetstoneId(orderNetstoneId: Long): InvoiceNetstone? =
+    invoiceNetstoneRepository.findDetailedByOrderNetstoneId(orderNetstoneId)
+
+  /** Loads the invoice lines persisted for the given invoice. */
+  @Transactional(readOnly = true)
+  fun findLines(invoiceId: Long): List<DocumentLine> =
+    documentLineService.findLines(DocumentLine.DocumentType.INVOICE_NETSTONE, invoiceId)
+
+  /** Loads a single invoice by id. */
+  @Transactional(readOnly = true)
+  fun findById(id: Long): Optional<InvoiceNetstone> =
+    Optional.ofNullable(invoiceNetstoneRepository.findDetailedById(id))
+
+  /** Returns the preview number shown before a Netstone invoice is first saved. */
+  @Transactional(readOnly = true)
+  fun previewNextInvoiceNumber(invoiceDate: LocalDate): String =
+    numberSequenceService.previewNextNumber(sequenceKey(invoiceDate), previewPrefix(invoiceDate), 3)
+
+  /** Prepares an existing invoice or a prefilled draft invoice for the given Netstone sale. */
+  @Transactional(readOnly = true)
+  fun prepareForSale(sale: SalesNetstone, order: OrderNetstone): InvoiceNetstone =
+    order.id?.let(::findByOrderNetstoneId)
+      ?: order.invoiceNetstone
+      ?: createDraftInvoice(sale, order)
+
+  private fun createDraftInvoice(sale: SalesNetstone, order: OrderNetstone): InvoiceNetstone {
+    val codig =
+      clientService.findDefaultCodigCompany().orElseThrow {
+        IllegalStateException("Aucune societe Codig n'est configuree")
+      }
+    return InvoiceNetstone(
+        "",
+        InvoiceNetstone.RecipientType.COMPANY_CODIG,
+        codig,
+        sale.saleDate ?: order.orderDate ?: order.orderCodig.orderDate,
+      )
+      .apply {
+        recipient = codig
+        billingAddress = codig.billingAddress
+        orderNetstone = order
+        origin = InvoiceNetstone.Origin.ORDER_LINKED
+        dueDate = sale.expectedDeliveryDate
+        notes = sale.notes
+      }
+  }
+
+  /** Saves the invoice and replaces its lines from the current editor content. */
+  @Transactional
+  fun saveWithLines(invoice: InvoiceNetstone, lines: List<DocumentLine>): InvoiceNetstone {
+    val isNew = invoice.internalInvoiceNumber.isBlank()
+    if (isNew) {
+      invoice.internalInvoiceNumber =
+        numberSequenceService.nextNumber(
+          sequenceKey(invoice.invoiceDate),
+          previewPrefix(invoice.invoiceDate),
+          3,
+        )
+    }
+    if (invoice.orderNetstone == null) {
+      error("La facture Netstone doit etre rattachee a une commande Netstone")
+    }
+    invoice.origin = InvoiceNetstone.Origin.ORDER_LINKED
+    if (invoice.recipientType == InvoiceNetstone.RecipientType.COMPANY_CODIG) {
+      val codig =
+        clientService.findDefaultCodigCompany().orElseThrow {
+          IllegalStateException("Aucune societe Codig n'est configuree")
+        }
+      invoice.recipient = codig
+      if (invoice.billingAddress.isNullOrBlank()) {
+        invoice.billingAddress = codig.billingAddress
+      }
+    }
+
+    val saved = invoiceNetstoneRepository.save(invoice)
+    val persistedLines =
+      documentLineService.replaceLines(DocumentLine.DocumentType.INVOICE_NETSTONE, saved.id!!, lines)
+    saved.recalculateTotals(persistedLines)
+    val persistedInvoice = invoiceNetstoneRepository.save(saved)
+
+    val order = persistedInvoice.orderNetstone ?: error("Commande Netstone introuvable")
+    if (order.invoiceNetstone?.id != persistedInvoice.id) {
+      order.invoiceNetstone = persistedInvoice
+      orderNetstoneRepository.save(order)
+    }
+
+    if (isNew) {
+      invoicesCreatedCounter.increment()
+      log.info(
+        "InvoiceNetstone created: number={} order={}",
+        persistedInvoice.internalInvoiceNumber,
+        order.orderNumber,
+      )
+    }
+    return persistedInvoice
+  }
+
+  private fun sequenceKey(invoiceDate: LocalDate): String =
+    "${NumberSequenceService.INVOICE_NETSTONE}_${invoiceDate.year}"
+
+  private fun previewPrefix(invoiceDate: LocalDate): String = "NST_INV/${invoiceDate.year}/"
+}

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
@@ -1,0 +1,206 @@
+package fr.axl.lvy.invoice.ui
+
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.button.ButtonVariant
+import com.vaadin.flow.component.combobox.ComboBox
+import com.vaadin.flow.component.datepicker.DatePicker
+import com.vaadin.flow.component.dialog.Dialog
+import com.vaadin.flow.component.formlayout.FormLayout
+import com.vaadin.flow.component.html.Anchor
+import com.vaadin.flow.component.notification.Notification
+import com.vaadin.flow.component.notification.NotificationVariant
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.component.textfield.TextArea
+import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.server.StreamResource
+import fr.axl.lvy.base.ui.noGap
+import fr.axl.lvy.delivery.DeliveryNoteNetstone
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.ui.DocumentLineEditor
+import fr.axl.lvy.invoice.InvoiceCodig
+import fr.axl.lvy.invoice.InvoiceCodigService
+import fr.axl.lvy.order.OrderCodig
+import fr.axl.lvy.pdf.PdfService
+import fr.axl.lvy.product.ProductService
+import fr.axl.lvy.sale.SalesCodig
+
+internal class InvoiceCodigFormDialog(
+  private val invoiceCodigService: InvoiceCodigService,
+  private val productService: ProductService,
+  private val pdfService: PdfService,
+  private val sale: SalesCodig,
+  private val orderCodig: OrderCodig,
+  private val invoice: InvoiceCodig,
+  private val netstoneDeliveryNote: DeliveryNoteNetstone?,
+  saleLines: List<DocumentLine>,
+  initialLines: List<DocumentLine>,
+  private val onSave: Runnable,
+) : Dialog() {
+
+  private val invoiceNumber = TextField("N° Facture")
+  private val saleNumber = TextField("Vente CoDIG")
+  private val status = ComboBox<InvoiceFormStatus>("Statut")
+  private val invoiceDate = DatePicker("Date facture")
+  private val dueDate = DatePicker("Echeance")
+  private val clientName = TextField("Client")
+  private val clientReference = TextField("Réf. client")
+  private val paymentTerm = TextField("Condition de paiement")
+  private val fiscalPosition = TextField("Position fiscale")
+  private val incoterm = TextField("Incoterm")
+  private val incotermLocation = TextField("Emplacement")
+  private val billOfLading = TextField("BL")
+  private val containerNumber = TextField("N° de conteneur")
+  private val seals = TextField("Seals")
+  private val clientAddress = TextArea("Adresse facturation")
+  private val notes = TextArea("Notes")
+  private val lineEditor =
+    DocumentLineEditor(
+      productService = productService,
+      documentType = DocumentLine.DocumentType.INVOICE_CODIG,
+      clientSupplier = { sale.client },
+      currencySupplier = { invoice.currency },
+      unitPriceOverrideProvider = { product ->
+        saleLines.firstOrNull { it.product?.id == product.id }?.unitPriceExclTax
+      },
+      lineTaxMode = DocumentLineEditor.LineTaxMode.VAT,
+    )
+
+  init {
+    headerTitle =
+      if (invoice.id == null) "Nouvelle facture CoDIG" else "Facture CoDIG ${invoice.invoiceNumber}"
+    width = "960px"
+    height = "85%"
+
+    invoiceNumber.isReadOnly = true
+    saleNumber.isReadOnly = true
+    saleNumber.value = sale.saleNumber
+    status.setItems(*InvoiceFormStatus.entries.toTypedArray())
+    status.setItemLabelGenerator(::statusLabel)
+    clientName.isReadOnly = true
+    clientReference.isReadOnly = true
+    paymentTerm.isReadOnly = true
+    fiscalPosition.isReadOnly = true
+    incoterm.isReadOnly = true
+    incotermLocation.isReadOnly = true
+    billOfLading.isReadOnly = true
+    containerNumber.isReadOnly = true
+    seals.isReadOnly = true
+    invoiceDate.addValueChangeListener {
+      if (invoice.id == null) {
+        invoiceNumber.value =
+          invoiceCodigService.previewNextInvoiceNumber(it.value ?: sale.saleDate)
+      }
+    }
+
+    val form = FormLayout()
+    form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
+    form.add(invoiceNumber, saleNumber)
+    form.add(status, invoiceDate)
+    form.add(dueDate)
+    form.add(clientName, 2)
+    form.add(clientReference, paymentTerm)
+    form.add(fiscalPosition, incoterm)
+    form.add(incotermLocation, billOfLading)
+    form.add(containerNumber, seals)
+    form.add(clientAddress, 2)
+    form.add(notes, 2)
+
+    populateForm(invoice)
+    lineEditor.setLines(initialLines)
+
+    val content = VerticalLayout(form, lineEditor)
+    content.noGap()
+    add(content)
+
+    val saveBtn = Button("Enregistrer") { save() }
+    saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
+    val cancelBtn = Button("Annuler") { close() }
+    val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
+    if (invoice.id != null) {
+      val pdfResource =
+        StreamResource("${invoice.invoiceNumber.replace("/", "_")}.pdf") {
+            pdfService.generateInvoiceCodigPdf(invoice.id!!).inputStream()
+          }
+          .apply { cacheTime = 0 }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink =
+        Anchor(pdfResource, "").apply {
+          element.setAttribute("download", true)
+          add(pdfBtn)
+        }
+      footerLayout.add(pdfLink)
+    }
+    footer.add(footerLayout)
+  }
+
+  private fun populateForm(invoice: InvoiceCodig) {
+    invoiceNumber.value =
+      invoice.invoiceNumber.ifBlank {
+        invoiceCodigService.previewNextInvoiceNumber(invoice.invoiceDate)
+      }
+    invoiceDate.value = invoice.invoiceDate
+    status.value = invoice.status.toFormStatus()
+    dueDate.value = invoice.dueDate
+    clientName.value = sale.client.name
+    clientReference.value = sale.clientReference ?: ""
+    paymentTerm.value = sale.paymentTerm?.label ?: ""
+    fiscalPosition.value = sale.fiscalPosition?.position ?: ""
+    incoterm.value = sale.incoterms ?: ""
+    incotermLocation.value = sale.incotermLocation ?: ""
+    billOfLading.value = netstoneDeliveryNote?.billOfLading ?: ""
+    containerNumber.value = netstoneDeliveryNote?.containerNumber ?: ""
+    seals.value = netstoneDeliveryNote?.seals ?: ""
+    clientAddress.value = invoice.clientAddress ?: sale.billingAddress ?: sale.client.billingAddress ?: ""
+    notes.value = invoice.notes ?: ""
+  }
+
+  private fun save() {
+    invoice.orderCodig = orderCodig
+    invoice.deliveryNote = orderCodig.deliveryNote
+    invoice.client = sale.client
+    invoice.status = status.value.toInvoiceStatus()
+    invoice.invoiceDate = invoiceDate.value ?: sale.saleDate
+    invoice.dueDate = dueDate.value
+    invoice.clientName = sale.client.name
+    invoice.clientAddress =
+      clientAddress.value.takeIf { it.isNotBlank() }
+        ?: sale.billingAddress
+        ?: sale.client.billingAddress
+    invoice.clientSiret = sale.client.siret
+    invoice.clientVatNumber = sale.client.vatNumber
+    invoice.currency = sale.currency
+    invoice.incoterms = sale.incoterms
+    invoice.notes = notes.value.takeIf { it.isNotBlank() }
+
+    val saved = invoiceCodigService.saveWithLines(invoice, lineEditor.getLines())
+    invoiceNumber.value = saved.invoiceNumber
+    Notification.show("Facture CoDIG enregistrée", 3000, Notification.Position.BOTTOM_END)
+      .addThemeVariants(NotificationVariant.LUMO_SUCCESS)
+    onSave.run()
+    close()
+  }
+
+  private fun statusLabel(status: InvoiceFormStatus): String =
+    when (status) {
+      InvoiceFormStatus.DRAFT -> "Brouillon"
+      InvoiceFormStatus.VALIDATED -> "Validee"
+    }
+
+  private fun InvoiceCodig.InvoiceCodigStatus.toFormStatus(): InvoiceFormStatus =
+    when (this) {
+      InvoiceCodig.InvoiceCodigStatus.DRAFT -> InvoiceFormStatus.DRAFT
+      else -> InvoiceFormStatus.VALIDATED
+    }
+
+  private fun InvoiceFormStatus?.toInvoiceStatus(): InvoiceCodig.InvoiceCodigStatus =
+    when (this ?: InvoiceFormStatus.DRAFT) {
+      InvoiceFormStatus.DRAFT -> InvoiceCodig.InvoiceCodigStatus.DRAFT
+      InvoiceFormStatus.VALIDATED -> InvoiceCodig.InvoiceCodigStatus.ISSUED
+    }
+
+  private enum class InvoiceFormStatus {
+    DRAFT,
+    VALIDATED,
+  }
+}

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
@@ -151,7 +151,8 @@ internal class InvoiceCodigFormDialog(
     billOfLading.value = netstoneDeliveryNote?.billOfLading ?: ""
     containerNumber.value = netstoneDeliveryNote?.containerNumber ?: ""
     seals.value = netstoneDeliveryNote?.seals ?: ""
-    clientAddress.value = invoice.clientAddress ?: sale.billingAddress ?: sale.client.billingAddress ?: ""
+    clientAddress.value =
+      invoice.clientAddress ?: sale.billingAddress ?: sale.client.billingAddress ?: ""
     notes.value = invoice.notes ?: ""
   }
 

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
@@ -25,6 +25,11 @@ import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodig
 
+/**
+ * Dialog used to create or edit a [InvoiceCodig] from a [SalesCodig]. The form is read-only for the
+ * sale-derived fields (client, references, terms) and lets the user adjust invoice metadata and
+ * lines before saving.
+ */
 internal class InvoiceCodigFormDialog(
   private val invoiceCodigService: InvoiceCodigService,
   private val productService: ProductService,
@@ -40,9 +45,9 @@ internal class InvoiceCodigFormDialog(
 
   private val invoiceNumber = TextField("N° Facture")
   private val saleNumber = TextField("Vente CoDIG")
-  private val status = ComboBox<InvoiceFormStatus>("Statut")
+  private val status = ComboBox<InvoiceCodig.InvoiceCodigStatus>("Statut")
   private val invoiceDate = DatePicker("Date facture")
-  private val dueDate = DatePicker("Echeance")
+  private val dueDate = DatePicker("Échéance")
   private val clientName = TextField("Client")
   private val clientReference = TextField("Réf. client")
   private val paymentTerm = TextField("Condition de paiement")
@@ -75,7 +80,7 @@ internal class InvoiceCodigFormDialog(
     invoiceNumber.isReadOnly = true
     saleNumber.isReadOnly = true
     saleNumber.value = sale.saleNumber
-    status.setItems(*InvoiceFormStatus.entries.toTypedArray())
+    status.setItems(*InvoiceCodig.InvoiceCodigStatus.entries.toTypedArray())
     status.setItemLabelGenerator(::statusLabel)
     clientName.isReadOnly = true
     clientReference.isReadOnly = true
@@ -97,7 +102,7 @@ internal class InvoiceCodigFormDialog(
     form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
     form.add(invoiceNumber, saleNumber)
     form.add(status, invoiceDate)
-    form.add(dueDate)
+    form.add(dueDate, 2)
     form.add(clientName, 2)
     form.add(clientReference, paymentTerm)
     form.add(fiscalPosition, incoterm)
@@ -140,7 +145,7 @@ internal class InvoiceCodigFormDialog(
         invoiceCodigService.previewNextInvoiceNumber(invoice.invoiceDate)
       }
     invoiceDate.value = invoice.invoiceDate
-    status.value = invoice.status.toFormStatus()
+    status.value = invoice.status
     dueDate.value = invoice.dueDate
     clientName.value = sale.client.name
     clientReference.value = sale.clientReference ?: ""
@@ -160,7 +165,7 @@ internal class InvoiceCodigFormDialog(
     invoice.orderCodig = orderCodig
     invoice.deliveryNote = orderCodig.deliveryNote
     invoice.client = sale.client
-    invoice.status = status.value.toInvoiceStatus()
+    invoice.status = status.value ?: InvoiceCodig.InvoiceCodigStatus.DRAFT
     invoice.invoiceDate = invoiceDate.value ?: sale.saleDate
     invoice.dueDate = dueDate.value
     invoice.clientName = sale.client.name
@@ -182,26 +187,13 @@ internal class InvoiceCodigFormDialog(
     close()
   }
 
-  private fun statusLabel(status: InvoiceFormStatus): String =
+  private fun statusLabel(status: InvoiceCodig.InvoiceCodigStatus): String =
     when (status) {
-      InvoiceFormStatus.DRAFT -> "Brouillon"
-      InvoiceFormStatus.VALIDATED -> "Validee"
+      InvoiceCodig.InvoiceCodigStatus.DRAFT -> "Brouillon"
+      InvoiceCodig.InvoiceCodigStatus.ISSUED -> "Émise"
+      InvoiceCodig.InvoiceCodigStatus.OVERDUE -> "En retard"
+      InvoiceCodig.InvoiceCodigStatus.PAID -> "Payée"
+      InvoiceCodig.InvoiceCodigStatus.CANCELLED -> "Annulée"
+      InvoiceCodig.InvoiceCodigStatus.CREDIT_NOTE -> "Avoir"
     }
-
-  private fun InvoiceCodig.InvoiceCodigStatus.toFormStatus(): InvoiceFormStatus =
-    when (this) {
-      InvoiceCodig.InvoiceCodigStatus.DRAFT -> InvoiceFormStatus.DRAFT
-      else -> InvoiceFormStatus.VALIDATED
-    }
-
-  private fun InvoiceFormStatus?.toInvoiceStatus(): InvoiceCodig.InvoiceCodigStatus =
-    when (this ?: InvoiceFormStatus.DRAFT) {
-      InvoiceFormStatus.DRAFT -> InvoiceCodig.InvoiceCodigStatus.DRAFT
-      InvoiceFormStatus.VALIDATED -> InvoiceCodig.InvoiceCodigStatus.ISSUED
-    }
-
-  private enum class InvoiceFormStatus {
-    DRAFT,
-    VALIDATED,
-  }
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
@@ -24,6 +24,11 @@ import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesNetstone
 
+/**
+ * Dialog used to create or edit an [InvoiceNetstone] from a [SalesNetstone]. The recipient is
+ * resolved from the persisted invoice rather than hardcoded so external recipients are also
+ * supported.
+ */
 internal class InvoiceNetstoneFormDialog(
   private val invoiceNetstoneService: InvoiceNetstoneService,
   private val productService: ProductService,
@@ -37,10 +42,11 @@ internal class InvoiceNetstoneFormDialog(
 ) : Dialog() {
 
   private val invoiceNumber = TextField("N° Facture interne")
+  private val supplierInvoiceNumber = TextField("N° Facture fournisseur")
   private val saleNumber = TextField("Vente Netstone")
-  private val status = ComboBox<InvoiceFormStatus>("Statut")
+  private val status = ComboBox<InvoiceNetstone.InvoiceNetstoneStatus>("Statut")
   private val invoiceDate = DatePicker("Date facture")
-  private val dueDate = DatePicker("Echeance")
+  private val dueDate = DatePicker("Échéance")
   private val clientName = TextField("Client")
   private val clientReference = TextField("Réf. client")
   private val paymentTerm = TextField("Condition de paiement")
@@ -69,7 +75,7 @@ internal class InvoiceNetstoneFormDialog(
     invoiceNumber.isReadOnly = true
     saleNumber.isReadOnly = true
     saleNumber.value = sale.saleNumber
-    status.setItems(*InvoiceFormStatus.entries.toTypedArray())
+    status.setItems(*InvoiceNetstone.InvoiceNetstoneStatus.entries.toTypedArray())
     status.setItemLabelGenerator(::statusLabel)
     clientName.isReadOnly = true
     clientReference.isReadOnly = true
@@ -87,9 +93,9 @@ internal class InvoiceNetstoneFormDialog(
 
     val form = FormLayout()
     form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
-    form.add(invoiceNumber, saleNumber)
-    form.add(status, invoiceDate)
-    form.add(dueDate)
+    form.add(invoiceNumber, supplierInvoiceNumber)
+    form.add(saleNumber, status)
+    form.add(invoiceDate, dueDate)
     form.add(clientName, 2)
     form.add(clientReference, paymentTerm)
     form.add(incoterm, incotermLocation)
@@ -129,10 +135,11 @@ internal class InvoiceNetstoneFormDialog(
       invoice.internalInvoiceNumber.ifBlank {
         invoiceNetstoneService.previewNextInvoiceNumber(invoice.invoiceDate)
       }
+    supplierInvoiceNumber.value = invoice.supplierInvoiceNumber ?: ""
     invoiceDate.value = invoice.invoiceDate
-    status.value = invoice.status.toFormStatus()
+    status.value = invoice.status
     dueDate.value = invoice.dueDate
-    clientName.value = "CoDIG"
+    clientName.value = invoice.recipient.name
     clientReference.value = orderNetstone.orderCodig.orderNumber
     paymentTerm.value = sale.salesCodig.paymentTerm?.label ?: ""
     incoterm.value = sale.incoterms ?: ""
@@ -144,11 +151,11 @@ internal class InvoiceNetstoneFormDialog(
   private fun save() {
     invoice.orderNetstone = orderNetstone
     invoice.recipientType = InvoiceNetstone.RecipientType.COMPANY_CODIG
-    invoice.status = status.value.toInvoiceStatus()
+    invoice.status = status.value ?: InvoiceNetstone.InvoiceNetstoneStatus.RECEIVED
     invoice.invoiceDate = invoiceDate.value ?: sale.saleDate ?: orderNetstone.orderCodig.orderDate
     invoice.dueDate = dueDate.value
     invoice.billingAddress = billingAddress.value.takeIf { it.isNotBlank() }
-    invoice.supplierInvoiceNumber = null
+    invoice.supplierInvoiceNumber = supplierInvoiceNumber.value.takeIf { it.isNotBlank() }
     invoice.notes = notes.value.takeIf { it.isNotBlank() }
 
     val saved = invoiceNetstoneService.saveWithLines(invoice, lineEditor.getLines())
@@ -159,26 +166,11 @@ internal class InvoiceNetstoneFormDialog(
     close()
   }
 
-  private fun statusLabel(status: InvoiceFormStatus): String =
+  private fun statusLabel(status: InvoiceNetstone.InvoiceNetstoneStatus): String =
     when (status) {
-      InvoiceFormStatus.DRAFT -> "Brouillon"
-      InvoiceFormStatus.VALIDATED -> "Validee"
+      InvoiceNetstone.InvoiceNetstoneStatus.RECEIVED -> "Reçue"
+      InvoiceNetstone.InvoiceNetstoneStatus.VERIFIED -> "Vérifiée"
+      InvoiceNetstone.InvoiceNetstoneStatus.PAID -> "Payée"
+      InvoiceNetstone.InvoiceNetstoneStatus.DISPUTED -> "Litige"
     }
-
-  private fun InvoiceNetstone.InvoiceNetstoneStatus.toFormStatus(): InvoiceFormStatus =
-    when (this) {
-      InvoiceNetstone.InvoiceNetstoneStatus.RECEIVED -> InvoiceFormStatus.DRAFT
-      else -> InvoiceFormStatus.VALIDATED
-    }
-
-  private fun InvoiceFormStatus?.toInvoiceStatus(): InvoiceNetstone.InvoiceNetstoneStatus =
-    when (this ?: InvoiceFormStatus.DRAFT) {
-      InvoiceFormStatus.DRAFT -> InvoiceNetstone.InvoiceNetstoneStatus.RECEIVED
-      InvoiceFormStatus.VALIDATED -> InvoiceNetstone.InvoiceNetstoneStatus.VERIFIED
-    }
-
-  private enum class InvoiceFormStatus {
-    DRAFT,
-    VALIDATED,
-  }
 }

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
@@ -127,9 +127,7 @@ internal class InvoiceNetstoneFormDialog(
   private fun populateForm(invoice: InvoiceNetstone) {
     invoiceNumber.value =
       invoice.internalInvoiceNumber.ifBlank {
-        invoiceNetstoneService.previewNextInvoiceNumber(
-          invoice.invoiceDate
-        )
+        invoiceNetstoneService.previewNextInvoiceNumber(invoice.invoiceDate)
       }
     invoiceDate.value = invoice.invoiceDate
     status.value = invoice.status.toFormStatus()

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
@@ -1,0 +1,186 @@
+package fr.axl.lvy.invoice.ui
+
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.button.ButtonVariant
+import com.vaadin.flow.component.combobox.ComboBox
+import com.vaadin.flow.component.datepicker.DatePicker
+import com.vaadin.flow.component.dialog.Dialog
+import com.vaadin.flow.component.formlayout.FormLayout
+import com.vaadin.flow.component.html.Anchor
+import com.vaadin.flow.component.notification.Notification
+import com.vaadin.flow.component.notification.NotificationVariant
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.component.textfield.TextArea
+import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.server.StreamResource
+import fr.axl.lvy.base.ui.noGap
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.documentline.ui.DocumentLineEditor
+import fr.axl.lvy.invoice.InvoiceNetstone
+import fr.axl.lvy.invoice.InvoiceNetstoneService
+import fr.axl.lvy.order.OrderNetstone
+import fr.axl.lvy.pdf.PdfService
+import fr.axl.lvy.product.ProductService
+import fr.axl.lvy.sale.SalesNetstone
+
+internal class InvoiceNetstoneFormDialog(
+  private val invoiceNetstoneService: InvoiceNetstoneService,
+  private val productService: ProductService,
+  private val pdfService: PdfService,
+  private val sale: SalesNetstone,
+  private val orderNetstone: OrderNetstone,
+  private val invoice: InvoiceNetstone,
+  saleLines: List<DocumentLine>,
+  initialLines: List<DocumentLine>,
+  private val onSave: Runnable,
+) : Dialog() {
+
+  private val invoiceNumber = TextField("N° Facture interne")
+  private val saleNumber = TextField("Vente Netstone")
+  private val status = ComboBox<InvoiceFormStatus>("Statut")
+  private val invoiceDate = DatePicker("Date facture")
+  private val dueDate = DatePicker("Echeance")
+  private val clientName = TextField("Client")
+  private val clientReference = TextField("Réf. client")
+  private val paymentTerm = TextField("Condition de paiement")
+  private val incoterm = TextField("Incoterm")
+  private val incotermLocation = TextField("Emplacement")
+  private val billingAddress = TextArea("Adresse de facturation")
+  private val notes = TextArea("Notes")
+  private val lineEditor =
+    DocumentLineEditor(
+      productService = productService,
+      documentType = DocumentLine.DocumentType.INVOICE_NETSTONE,
+      clientSupplier = { sale.salesCodig.client },
+      unitPriceOverrideProvider = { product ->
+        saleLines.firstOrNull { it.product?.id == product.id }?.unitPriceExclTax
+      },
+      lineTaxMode = DocumentLineEditor.LineTaxMode.VAT,
+    )
+
+  init {
+    headerTitle =
+      if (invoice.id == null) "Nouvelle facture Netstone"
+      else "Facture Netstone ${invoice.internalInvoiceNumber}"
+    width = "960px"
+    height = "85%"
+
+    invoiceNumber.isReadOnly = true
+    saleNumber.isReadOnly = true
+    saleNumber.value = sale.saleNumber
+    status.setItems(*InvoiceFormStatus.entries.toTypedArray())
+    status.setItemLabelGenerator(::statusLabel)
+    clientName.isReadOnly = true
+    clientReference.isReadOnly = true
+    paymentTerm.isReadOnly = true
+    incoterm.isReadOnly = true
+    incotermLocation.isReadOnly = true
+    invoiceDate.addValueChangeListener {
+      if (invoice.id == null) {
+        invoiceNumber.value =
+          invoiceNetstoneService.previewNextInvoiceNumber(
+            it.value ?: sale.saleDate ?: orderNetstone.orderCodig.orderDate
+          )
+      }
+    }
+
+    val form = FormLayout()
+    form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
+    form.add(invoiceNumber, saleNumber)
+    form.add(status, invoiceDate)
+    form.add(dueDate)
+    form.add(clientName, 2)
+    form.add(clientReference, paymentTerm)
+    form.add(incoterm, incotermLocation)
+    form.add(billingAddress, 2)
+    form.add(notes, 2)
+
+    populateForm(invoice)
+    lineEditor.setLines(initialLines)
+
+    val content = VerticalLayout(form, lineEditor)
+    content.noGap()
+    add(content)
+
+    val saveBtn = Button("Enregistrer") { save() }
+    saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
+    val cancelBtn = Button("Annuler") { close() }
+    val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
+    if (invoice.id != null) {
+      val pdfResource =
+        StreamResource("${invoice.internalInvoiceNumber.replace("/", "_")}.pdf") {
+            pdfService.generateInvoiceNetstonePdf(invoice.id!!).inputStream()
+          }
+          .apply { cacheTime = 0 }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink =
+        Anchor(pdfResource, "").apply {
+          element.setAttribute("download", true)
+          add(pdfBtn)
+        }
+      footerLayout.add(pdfLink)
+    }
+    footer.add(footerLayout)
+  }
+
+  private fun populateForm(invoice: InvoiceNetstone) {
+    invoiceNumber.value =
+      invoice.internalInvoiceNumber.ifBlank {
+        invoiceNetstoneService.previewNextInvoiceNumber(
+          invoice.invoiceDate
+        )
+      }
+    invoiceDate.value = invoice.invoiceDate
+    status.value = invoice.status.toFormStatus()
+    dueDate.value = invoice.dueDate
+    clientName.value = "CoDIG"
+    clientReference.value = orderNetstone.orderCodig.orderNumber
+    paymentTerm.value = sale.salesCodig.paymentTerm?.label ?: ""
+    incoterm.value = sale.incoterms ?: ""
+    incotermLocation.value = sale.incotermLocation ?: ""
+    billingAddress.value = invoice.billingAddress ?: invoice.recipient.billingAddress ?: ""
+    notes.value = invoice.notes ?: ""
+  }
+
+  private fun save() {
+    invoice.orderNetstone = orderNetstone
+    invoice.recipientType = InvoiceNetstone.RecipientType.COMPANY_CODIG
+    invoice.status = status.value.toInvoiceStatus()
+    invoice.invoiceDate = invoiceDate.value ?: sale.saleDate ?: orderNetstone.orderCodig.orderDate
+    invoice.dueDate = dueDate.value
+    invoice.billingAddress = billingAddress.value.takeIf { it.isNotBlank() }
+    invoice.supplierInvoiceNumber = null
+    invoice.notes = notes.value.takeIf { it.isNotBlank() }
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, lineEditor.getLines())
+    invoiceNumber.value = saved.internalInvoiceNumber
+    Notification.show("Facture Netstone enregistrée", 3000, Notification.Position.BOTTOM_END)
+      .addThemeVariants(NotificationVariant.LUMO_SUCCESS)
+    onSave.run()
+    close()
+  }
+
+  private fun statusLabel(status: InvoiceFormStatus): String =
+    when (status) {
+      InvoiceFormStatus.DRAFT -> "Brouillon"
+      InvoiceFormStatus.VALIDATED -> "Validee"
+    }
+
+  private fun InvoiceNetstone.InvoiceNetstoneStatus.toFormStatus(): InvoiceFormStatus =
+    when (this) {
+      InvoiceNetstone.InvoiceNetstoneStatus.RECEIVED -> InvoiceFormStatus.DRAFT
+      else -> InvoiceFormStatus.VALIDATED
+    }
+
+  private fun InvoiceFormStatus?.toInvoiceStatus(): InvoiceNetstone.InvoiceNetstoneStatus =
+    when (this ?: InvoiceFormStatus.DRAFT) {
+      InvoiceFormStatus.DRAFT -> InvoiceNetstone.InvoiceNetstoneStatus.RECEIVED
+      InvoiceFormStatus.VALIDATED -> InvoiceNetstone.InvoiceNetstoneStatus.VERIFIED
+    }
+
+  private enum class InvoiceFormStatus {
+    DRAFT,
+    VALIDATED,
+  }
+}

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigListView.kt
@@ -139,6 +139,7 @@ internal class CommandCodigListView(
         clientService,
         salesCodigService,
         incotermService,
+        paymentTermService,
         fiscalPositionService,
         productService,
         pdfService,

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneListView.kt
@@ -100,6 +100,7 @@ internal class CommandNetstoneListView(
         clientService,
         salesCodigService,
         incotermService,
+        paymentTermService,
         fiscalPositionService,
         productService,
         pdfService,

--- a/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
+++ b/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
@@ -7,6 +7,8 @@ import fr.axl.lvy.delivery.DeliveryNoteCodigService
 import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
+import fr.axl.lvy.invoice.InvoiceCodigService
+import fr.axl.lvy.invoice.InvoiceNetstoneService
 import fr.axl.lvy.order.OrderCodigService
 import fr.axl.lvy.order.OrderNetstoneService
 import fr.axl.lvy.product.ProductService
@@ -37,6 +39,8 @@ class PdfService(
   private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
   private val salesCodigService: SalesCodigService,
   private val salesNetstoneService: SalesNetstoneService,
+  private val invoiceCodigService: InvoiceCodigService,
+  private val invoiceNetstoneService: InvoiceNetstoneService,
   private val productService: ProductService,
   private val documentLineRepository: DocumentLineRepository,
   private val clientService: ClientService,
@@ -384,6 +388,130 @@ class PdfService(
     return out.toByteArray()
   }
 
+  /** Generates a PDF for a Codig invoice. */
+  @Transactional(readOnly = true)
+  fun generateInvoiceCodigPdf(invoiceId: Long): ByteArray {
+    val invoice =
+      invoiceCodigService.findById(invoiceId).orElseThrow {
+        IllegalArgumentException("InvoiceCodig $invoiceId not found")
+      }
+    val lines = invoiceCodigService.findLines(invoiceId).map { PdfLine.from(it, productService) }
+    val sale = invoice.orderCodig?.id?.let { salesCodigService.findByOrderCodigId(it).orElse(null) }
+    val netstoneDeliveryNote =
+      invoice.orderCodig
+        ?.id
+        ?.let { salesNetstoneService.findByOrderCodigId(it).orElse(null) }
+        ?.orderNetstone
+        ?.id
+        ?.let(deliveryNoteNetstoneService::findByOrderNetstoneId)
+    val ownCompany =
+      clientService
+        .findDefaultCodigCompany()
+        .flatMap { company ->
+          company.id?.let(clientService::findDetailedById) ?: java.util.Optional.of(company)
+        }
+        .orElse(null)
+    val client = sale?.client ?: invoice.client
+
+    val ctx = Context()
+    ctx.setVariable("invoice", invoice)
+    ctx.setVariable("sale", sale)
+    ctx.setVariable("client", client)
+    ctx.setVariable("lines", lines)
+    ctx.setVariable("ownCompany", ownCompany)
+    ctx.setVariable(
+      "ownCompanyAddressLines",
+      ownCompany?.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable(
+      "clientAddressLines",
+      client.billingAddress?.lines()
+        ?: sale?.billingAddress?.lines()
+        ?: invoice.clientAddress?.lines()
+        ?: emptyList<String>(),
+    )
+    ctx.setVariable(
+      "invoicingAddressLines",
+      invoice.clientAddress?.lines() ?: client.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable("logoSrc", logoSrc(ownCompany))
+    ctx.setVariable("currencySymbol", currencySymbol(invoice.currency))
+    ctx.setVariable("incotermText", sale?.incoterms ?: invoice.incoterms ?: "")
+    ctx.setVariable("incotermLocation", sale?.incotermLocation ?: "")
+    ctx.setVariable("paymentTermLabel", sale?.paymentTerm?.label ?: "")
+    ctx.setVariable("customerReference", sale?.clientReference ?: "")
+    ctx.setVariable("fiscalPositionRemark", sale?.fiscalPosition?.position ?: "")
+    ctx.setVariable("netstoneDeliveryNote", netstoneDeliveryNote)
+
+    val html = templateEngine.process("invoice-codig", ctx)
+
+    val out = ByteArrayOutputStream()
+    PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
+    return out.toByteArray()
+  }
+
+  /** Generates a PDF for a Netstone invoice billed to Codig. */
+  @Transactional(readOnly = true)
+  fun generateInvoiceNetstonePdf(invoiceId: Long): ByteArray {
+    val invoice =
+      invoiceNetstoneService.findById(invoiceId).orElseThrow {
+        IllegalArgumentException("InvoiceNetstone $invoiceId not found")
+      }
+    val lines = invoiceNetstoneService.findLines(invoiceId).map { PdfLine.from(it, productService) }
+    val ownCompany =
+      clientService
+        .findDefaultCodigSupplier()
+        .flatMap { company ->
+          company.id?.let(clientService::findDetailedById) ?: java.util.Optional.of(company)
+        }
+        .orElse(null)
+    val codigCompany =
+      clientService
+        .findDefaultCodigCompany()
+        .flatMap { company ->
+          company.id?.let(clientService::findDetailedById) ?: java.util.Optional.of(company)
+        }
+        .orElse(null)
+
+    val ctx = Context()
+    ctx.setVariable("invoice", invoice)
+    ctx.setVariable("client", codigCompany)
+    ctx.setVariable("lines", lines)
+    ctx.setVariable("ownCompany", ownCompany)
+    ctx.setVariable(
+      "ownCompanyAddressLines",
+      ownCompany?.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable(
+      "clientAddressLines",
+      codigCompany?.billingAddress?.lines()
+        ?: invoice.billingAddress?.lines()
+        ?: emptyList<String>(),
+    )
+    ctx.setVariable(
+      "invoicingAddressLines",
+      invoice.billingAddress?.lines()
+        ?: codigCompany?.billingAddress?.lines()
+        ?: emptyList<String>(),
+    )
+    ctx.setVariable("logoSrc", logoSrc(ownCompany))
+    ctx.setVariable(
+      "currencySymbol",
+      currencySymbol(invoice.orderNetstone?.orderCodig?.currency ?: "EUR"),
+    )
+    ctx.setVariable(
+      "incotermText",
+      incotermText(invoice.orderNetstone?.incoterms, invoice.orderNetstone?.incotermLocation),
+    )
+    ctx.setVariable("customerReference", invoice.orderNetstone?.orderCodig?.orderNumber ?: "")
+
+    val html = templateEngine.process("invoice-netstone", ctx)
+
+    val out = ByteArrayOutputStream()
+    PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
+    return out.toByteArray()
+  }
+
   private data class DeliveryPdfLine(
     val designation: String,
     val displayName: String,
@@ -447,6 +575,7 @@ class PdfService(
     val description: String?,
     val hsCode: String?,
     val madeIn: String?,
+    val clientProductCode: String?,
     val quantity: BigDecimal,
     val unit: String?,
     val unitPriceExclTax: BigDecimal,
@@ -463,6 +592,7 @@ class PdfService(
           description = line.description ?: product?.specifications,
           hsCode = line.hsCode ?: product?.hsCode,
           madeIn = line.madeIn ?: product?.madeIn,
+          clientProductCode = line.clientProductCode,
           quantity = line.quantity,
           unit = line.unit,
           unitPriceExclTax = line.unitPriceExclTax,

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesNetstone.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesNetstone.kt
@@ -3,6 +3,7 @@ package fr.axl.lvy.sale
 import fr.axl.lvy.base.TotalizableDocument
 import fr.axl.lvy.fiscalposition.FiscalPosition
 import fr.axl.lvy.order.OrderNetstone
+import fr.axl.lvy.paymentterm.PaymentTerm
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotBlank
 import java.math.BigDecimal
@@ -37,6 +38,10 @@ class SalesNetstone(
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "fiscal_position_id")
   var fiscalPosition: FiscalPosition? = null
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "payment_term_id")
+  var paymentTerm: PaymentTerm? = null
 
   @Column(nullable = false, length = 5) var currency: String = "EUR"
 

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query
 interface SalesNetstoneRepository : JpaRepository<SalesNetstone, Long> {
 
   @Query(
-    "SELECT s FROM SalesNetstone s LEFT JOIN FETCH s.salesCodig sc LEFT JOIN FETCH sc.client LEFT JOIN FETCH sc.orderCodig oc LEFT JOIN FETCH oc.client LEFT JOIN FETCH s.fiscalPosition LEFT JOIN FETCH s.orderNetstone WHERE s.deletedAt IS NULL"
+    "SELECT s FROM SalesNetstone s LEFT JOIN FETCH s.salesCodig sc LEFT JOIN FETCH sc.client LEFT JOIN FETCH sc.orderCodig oc LEFT JOIN FETCH oc.client LEFT JOIN FETCH s.fiscalPosition LEFT JOIN FETCH s.paymentTerm LEFT JOIN FETCH s.orderNetstone WHERE s.deletedAt IS NULL"
   )
   fun findByDeletedAtIsNull(): List<SalesNetstone>
 
@@ -23,6 +23,7 @@ interface SalesNetstoneRepository : JpaRepository<SalesNetstone, Long> {
       LEFT JOIN FETCH sc.orderCodig oc
       LEFT JOIN FETCH oc.client
       LEFT JOIN FETCH s.fiscalPosition
+      LEFT JOIN FETCH s.paymentTerm
       LEFT JOIN FETCH s.orderNetstone
       WHERE s.id = :id
     """
@@ -38,6 +39,7 @@ interface SalesNetstoneRepository : JpaRepository<SalesNetstone, Long> {
       LEFT JOIN FETCH sc.orderCodig oc
       LEFT JOIN FETCH oc.client
       LEFT JOIN FETCH s.fiscalPosition
+      LEFT JOIN FETCH s.paymentTerm
       LEFT JOIN FETCH s.orderNetstone
       WHERE sc.id = :salesCodigId AND s.deletedAt IS NULL
     """
@@ -53,6 +55,7 @@ interface SalesNetstoneRepository : JpaRepository<SalesNetstone, Long> {
       LEFT JOIN FETCH sc.orderCodig oc
       LEFT JOIN FETCH oc.client
       LEFT JOIN FETCH s.fiscalPosition
+      LEFT JOIN FETCH s.paymentTerm
       LEFT JOIN FETCH s.orderNetstone
       WHERE oc.id = :orderCodigId AND s.deletedAt IS NULL
     """

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneService.kt
@@ -75,6 +75,9 @@ class SalesNetstoneService(
       sale.fiscalPosition =
         clientService.findDefaultCodigSupplier().map { it.fiscalPosition }.orElse(null)
     }
+    if (sale.paymentTerm == null) {
+      sale.paymentTerm = orderCodig.paymentTerm
+    }
     if (sale.currency.isBlank()) {
       sale.currency = orderCodig.currency
     }
@@ -116,6 +119,7 @@ class SalesNetstoneService(
     sale.notes = notes
     sale.fiscalPosition =
       clientService.findDefaultCodigSupplier().map { it.fiscalPosition }.orElse(null)
+    sale.paymentTerm = sourceOrderCodig.paymentTerm
     sale.currency = sourceOrderCodig.currency
     sale.exchangeRate = sourceOrderCodig.exchangeRate
     sale.purchasePriceExclTax =
@@ -188,7 +192,7 @@ class SalesNetstoneService(
       }
     order.orderDate = sale.saleDate
     order.expectedDeliveryDate = sale.expectedDeliveryDate
-    order.paymentTerm = clientService.findDefaultCodigSupplier().map { it.paymentTerm }.orElse(null)
+    order.paymentTerm = sale.paymentTerm
     order.fiscalPosition =
       clientService.findDefaultCodigSupplier().map { it.fiscalPosition }.orElse(null)
     order.incoterms = sale.incoterms

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
@@ -319,8 +319,7 @@ internal class SalesCodigListView(
         ?.orderNetstone
         ?.id
         ?.let(deliveryNoteNetstoneService::findByOrderNetstoneId)
-    val initialLines =
-      invoice.id?.let { invoiceCodigService.findLines(it) } ?: saleLines
+    val initialLines = invoice.id?.let { invoiceCodigService.findLines(it) } ?: saleLines
 
     InvoiceCodigFormDialog(
         invoiceCodigService,

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
@@ -21,6 +21,8 @@ import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.delivery.ui.DeliveryNoteCodigFormDialog
 import fr.axl.lvy.fiscalposition.FiscalPositionService
 import fr.axl.lvy.incoterm.IncotermService
+import fr.axl.lvy.invoice.InvoiceCodigService
+import fr.axl.lvy.invoice.ui.InvoiceCodigFormDialog
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigService
 import fr.axl.lvy.order.OrderNetstoneService
@@ -47,6 +49,7 @@ internal class SalesCodigListView(
   private val deliveryNoteCodigService: DeliveryNoteCodigService,
   private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
   private val orderCodigService: OrderCodigService,
+  private val invoiceCodigService: InvoiceCodigService,
   private val salesNetstoneService: SalesNetstoneService,
   private val orderNetstoneService: OrderNetstoneService,
   private val pdfService: PdfService,
@@ -74,8 +77,11 @@ internal class SalesCodigListView(
         val deliveryButton = Button("Livraison") { openDeliveryForm(sale) }
         deliveryButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
         deliveryButton.isEnabled = sale.status == SalesStatus.VALIDATED
+        val invoiceButton = Button("Facture") { openInvoiceForm(sale) }
+        invoiceButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
+        invoiceButton.isEnabled = sale.orderCodig != null
 
-        HorizontalLayout(viewButton, deliveryButton).apply {
+        HorizontalLayout(viewButton, deliveryButton, invoiceButton).apply {
           isPadding = false
           isSpacing = true
         }
@@ -158,6 +164,7 @@ internal class SalesCodigListView(
         clientService,
         salesCodigService,
         incotermService,
+        paymentTermService,
         fiscalPositionService,
         productService,
         pdfService,
@@ -182,6 +189,7 @@ internal class SalesCodigListView(
         clientService,
         salesCodigService,
         incotermService,
+        paymentTermService,
         fiscalPositionService,
         productService,
         pdfService,
@@ -233,6 +241,7 @@ internal class SalesCodigListView(
         clientService,
         salesCodigService,
         incotermService,
+        paymentTermService,
         fiscalPositionService,
         productService,
         pdfService,
@@ -283,6 +292,46 @@ internal class SalesCodigListView(
         loadedSale.clientReference,
         netstoneDeliveryNote,
         deliveryNote,
+        this::refreshGrid,
+      )
+      .open()
+  }
+
+  private fun openInvoiceForm(sale: SalesCodig) {
+    val loadedSale = sale.id?.let { salesCodigService.findDetailedById(it).orElse(sale) } ?: sale
+    val orderCodig = loadedSale.orderCodig
+    if (orderCodig?.id == null) {
+      Notification.show(
+          "La facture n'est disponible que pour une vente avec commande CoDIG",
+          3000,
+          Notification.Position.BOTTOM_END,
+        )
+        .addThemeVariants(NotificationVariant.LUMO_ERROR)
+      return
+    }
+    val loadedOrder = orderCodigService.findDetailedById(orderCodig.id!!).orElse(orderCodig)
+    val invoice = invoiceCodigService.prepareForSale(loadedSale, loadedOrder)
+    val saleLines = salesCodigService.findLines(loadedSale.id!!)
+    val netstoneDeliveryNote =
+      salesNetstoneService
+        .findByOrderCodigId(orderCodig.id!!)
+        .orElse(null)
+        ?.orderNetstone
+        ?.id
+        ?.let(deliveryNoteNetstoneService::findByOrderNetstoneId)
+    val initialLines =
+      invoice.id?.let { invoiceCodigService.findLines(it) } ?: saleLines
+
+    InvoiceCodigFormDialog(
+        invoiceCodigService,
+        productService,
+        pdfService,
+        loadedSale,
+        loadedOrder,
+        invoice,
+        netstoneDeliveryNote,
+        saleLines,
+        initialLines,
         this::refreshGrid,
       )
       .open()

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
@@ -29,6 +29,8 @@ import fr.axl.lvy.incoterm.Incoterm
 import fr.axl.lvy.incoterm.IncotermService
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderNetstone
+import fr.axl.lvy.paymentterm.PaymentTerm
+import fr.axl.lvy.paymentterm.PaymentTermService
 import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodig
@@ -42,6 +44,7 @@ internal class SalesNetstoneFormDialog(
   private val clientService: ClientService,
   salesCodigService: SalesCodigService,
   incotermService: IncotermService,
+  paymentTermService: PaymentTermService,
   fiscalPositionService: FiscalPositionService,
   productService: ProductService,
   private val pdfService: PdfService,
@@ -59,6 +62,7 @@ internal class SalesNetstoneFormDialog(
   private val orderDate = DatePicker("Date vente")
   private val status = ComboBox<SalesStatus>("Statut")
   private val expectedDeliveryDate = DatePicker("Livraison prévue")
+  private val paymentTermCombo = ComboBox<PaymentTerm>("Conditions de paiement")
   private val fiscalPositionCombo = ComboBox<FiscalPosition>("Position fiscale")
   private val deliveryAddressCombo = ComboBox<ClientDeliveryAddress>("Adresse de livraison")
   private val incotermCombo = ComboBox<Incoterm>("Incoterm")
@@ -88,6 +92,8 @@ internal class SalesNetstoneFormDialog(
     }
     fiscalPositionCombo.setItems(fiscalPositionService.findAll())
     fiscalPositionCombo.setItemLabelGenerator { it.position }
+    paymentTermCombo.setItems(paymentTermService.findAll())
+    paymentTermCombo.setItemLabelGenerator { it.label }
     deliveryAddressCombo.setItemLabelGenerator { it.label }
 
     orderCodigCombo.setItems(
@@ -105,7 +111,7 @@ internal class SalesNetstoneFormDialog(
       if (linkedOrder == null) {
         it.saleNumber
       } else {
-        "${linkedOrder.orderNumber} - ${it.client.name}"
+        linkedOrder.orderNumber
       }
     }
     orderCodigCombo.addValueChangeListener { event ->
@@ -117,9 +123,9 @@ internal class SalesNetstoneFormDialog(
     form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
     form.add(orderNumber, orderCodigCombo)
     form.add(status, orderDate)
-    form.add(expectedDeliveryDate, fiscalPositionCombo)
-    form.add(deliveryAddressCombo, incotermCombo)
-    form.add(incotermLocation, 2)
+    form.add(expectedDeliveryDate, paymentTermCombo)
+    form.add(fiscalPositionCombo, deliveryAddressCombo)
+    form.add(incotermCombo, incotermLocation)
     form.add(notes, 2)
 
     lineEditor =
@@ -163,6 +169,7 @@ internal class SalesNetstoneFormDialog(
     } else {
       orderNumber.value = "(auto)"
       status.value = SalesStatus.DRAFT
+      paymentTermCombo.value = orderCodigCombo.value?.orderCodig?.paymentTerm
       fiscalPositionCombo.value =
         clientService.findDefaultCodigSupplier().map { it.fiscalPosition }.orElse(null)
     }
@@ -174,6 +181,7 @@ internal class SalesNetstoneFormDialog(
     orderDate.value = o.saleDate
     status.value = o.status
     expectedDeliveryDate.value = o.expectedDeliveryDate
+    paymentTermCombo.value = o.paymentTerm
     fiscalPositionCombo.value = o.fiscalPosition
     selectedCurrency = o.currency
     incotermCombo.value = allIncoterms.firstOrNull { it.name == o.incoterms }
@@ -187,6 +195,7 @@ internal class SalesNetstoneFormDialog(
   private fun applyLinkedOrderDefaults(salesCodig: SalesCodig) {
     val linkedOrder = salesCodig.orderCodig ?: return
     applyCodigDeliveryDefaults(salesCodig.shippingAddress)
+    paymentTermCombo.value = linkedOrder.paymentTerm
     incotermCombo.value = allIncoterms.firstOrNull { it.name == linkedOrder.incoterms }
     incotermLocation.value = linkedOrder.incotermLocation ?: ""
     selectedCurrency = linkedOrder.currency
@@ -224,6 +233,7 @@ internal class SalesNetstoneFormDialog(
     o.saleDate = orderDate.value
     o.status = status.value ?: SalesStatus.DRAFT
     o.expectedDeliveryDate = expectedDeliveryDate.value
+    o.paymentTerm = paymentTermCombo.value
     o.fiscalPosition = fiscalPositionCombo.value
     o.currency = selectedCurrency
     o.shippingAddress = deliveryAddressCombo.value?.address

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneListView.kt
@@ -19,6 +19,8 @@ import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
 import fr.axl.lvy.delivery.ui.DeliveryNoteNetstoneFormDialog
 import fr.axl.lvy.fiscalposition.FiscalPositionService
 import fr.axl.lvy.incoterm.IncotermService
+import fr.axl.lvy.invoice.InvoiceNetstoneService
+import fr.axl.lvy.invoice.ui.InvoiceNetstoneFormDialog
 import fr.axl.lvy.order.OrderCodigService
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.order.OrderNetstoneService
@@ -38,6 +40,7 @@ internal class SalesNetstoneListView(
   private val salesNetstoneService: SalesNetstoneService,
   private val orderNetstoneService: OrderNetstoneService,
   private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
+  private val invoiceNetstoneService: InvoiceNetstoneService,
   private val clientService: ClientService,
   private val salesCodigService: SalesCodigService,
   private val incotermService: IncotermService,
@@ -62,7 +65,7 @@ internal class SalesNetstoneListView(
         if (linkedOrder == null) {
           ""
         } else {
-          "${linkedOrder.orderNumber} - ${it.salesCodig.client.name}"
+          linkedOrder.orderNumber
         }
       }
       .setHeader("Commande CoDIG liée")
@@ -78,7 +81,10 @@ internal class SalesNetstoneListView(
         val deliveryButton = Button("Livraison") { openDeliveryForm(sale) }
         deliveryButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
         deliveryButton.isEnabled = sale.orderNetstone != null
-        HorizontalLayout(viewButton, deliveryButton).apply {
+        val invoiceButton = Button("Facture") { openInvoiceForm(sale) }
+        invoiceButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
+        invoiceButton.isEnabled = sale.orderNetstone != null
+        HorizontalLayout(viewButton, deliveryButton, invoiceButton).apply {
           isPadding = false
           isSpacing = true
         }
@@ -107,6 +113,7 @@ internal class SalesNetstoneListView(
         clientService,
         salesCodigService,
         incotermService,
+        paymentTermService,
         fiscalPositionService,
         productService,
         pdfService,
@@ -252,6 +259,38 @@ internal class SalesNetstoneListView(
         loadedSale.saleNumber,
         loadedSale.shippingAddress,
         deliveryNote,
+        initialLines,
+        this::refreshGrid,
+      )
+      .open()
+  }
+
+  private fun openInvoiceForm(sale: SalesNetstone) {
+    val loadedSale = sale.id?.let { salesNetstoneService.findDetailedById(it).orElse(sale) } ?: sale
+    val orderNetstone = loadedSale.orderNetstone
+    if (orderNetstone?.id == null) {
+      Notification.show(
+          "La facture n'est disponible que pour une vente avec commande Netstone",
+          3000,
+          Notification.Position.BOTTOM_END,
+        )
+        .addThemeVariants(NotificationVariant.LUMO_ERROR)
+      return
+    }
+    val loadedOrder = orderNetstoneService.findDetailedById(orderNetstone.id!!).orElse(orderNetstone)
+    val invoice = invoiceNetstoneService.prepareForSale(loadedSale, loadedOrder)
+    val saleLines = salesNetstoneService.findLines(loadedSale.id!!)
+    val initialLines =
+      invoice.id?.let { invoiceNetstoneService.findLines(it) } ?: saleLines
+
+    InvoiceNetstoneFormDialog(
+        invoiceNetstoneService,
+        productService,
+        pdfService,
+        loadedSale,
+        loadedOrder,
+        invoice,
+        saleLines,
         initialLines,
         this::refreshGrid,
       )

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneListView.kt
@@ -277,11 +277,11 @@ internal class SalesNetstoneListView(
         .addThemeVariants(NotificationVariant.LUMO_ERROR)
       return
     }
-    val loadedOrder = orderNetstoneService.findDetailedById(orderNetstone.id!!).orElse(orderNetstone)
+    val loadedOrder =
+      orderNetstoneService.findDetailedById(orderNetstone.id!!).orElse(orderNetstone)
     val invoice = invoiceNetstoneService.prepareForSale(loadedSale, loadedOrder)
     val saleLines = salesNetstoneService.findLines(loadedSale.id!!)
-    val initialLines =
-      invoice.id?.let { invoiceNetstoneService.findLines(it) } ?: saleLines
+    val initialLines = invoice.id?.let { invoiceNetstoneService.findLines(it) } ?: saleLines
 
     InvoiceNetstoneFormDialog(
         invoiceNetstoneService,

--- a/src/main/resources/templates/pdf/invoice-codig.html
+++ b/src/main/resources/templates/pdf/invoice-codig.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <style>
+    body { font-family: Arial, Helvetica, sans-serif; font-size: 11pt; color: #333333; margin: 0; padding: 0; }
+    p { margin: 0; padding: 0; }
+    .header-table { width: 100%; margin-bottom: 28pt; }
+    .logo-cell { width: 58%; vertical-align: top; }
+    .logo-cell img { height: 80pt; max-width: 180pt; }
+    .addr-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .company-name { font-size: 12pt; font-weight: bold; margin-bottom: 4pt; }
+    .parties-table { width: 100%; margin-bottom: 24pt; }
+    .left-cell { width: 58%; vertical-align: top; font-size: 10pt; }
+    .block-label { font-weight: bold; margin-bottom: 4pt; }
+    .address-block { margin-bottom: 12pt; }
+    .document-title { color: #E07028; font-size: 24pt; font-weight: bold; margin-bottom: 16pt; }
+    .meta-table { width: 100%; border-collapse: collapse; margin-bottom: 20pt; }
+    .meta-table th { color: #E07028; font-size: 9pt; font-weight: bold; text-align: left; padding: 0 8pt 3pt 0; }
+    .meta-table td { font-size: 10pt; padding: 0 8pt 0 0; vertical-align: top; }
+    .lines-table { width: 100%; border-collapse: collapse; border-top: 3pt double #333333; border-bottom: 3pt double #333333; margin-bottom: 16pt; }
+    .lines-table th { padding: 7pt 8pt; font-size: 9pt; font-weight: bold; text-align: left; }
+    .lines-table th.right, .lines-table td.right { text-align: right; }
+    .lines-table td { padding: 7pt 8pt; font-size: 10pt; vertical-align: top; }
+    .product-sub { font-size: 9pt; color: #666666; margin-top: 3pt; }
+    .totals-table { width: 220pt; margin-left: auto; border-collapse: collapse; }
+    .totals-table td { padding: 4pt 4pt; font-size: 10pt; }
+    .totals-table .amount { text-align: right; }
+    .totals-table .final-row td { border-top: 2pt solid #333333; color: #E07028; font-weight: bold; font-size: 12pt; }
+    .details-block { margin-top: 16pt; font-size: 10pt; line-height: 1.35; }
+    .detail-line { margin-bottom: 4pt; }
+    @page { margin: 18mm 18mm 22mm 18mm; @bottom-right { content: counter(page); font-size: 9pt; color: #777777; } }
+  </style>
+</head>
+<body>
+  <table class="header-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="logo-cell"><img th:if="${logoSrc != null}" th:src="${logoSrc}" alt=""/></td>
+      <td class="addr-cell" th:if="${ownCompany != null}">
+        <p class="company-name" th:text="${ownCompany.name}"></p>
+        <p th:each="line : ${ownCompanyAddressLines}" th:text="${line}"></p>
+        <p th:if="${ownCompany.vatNumber != null}" th:text="${'TVA: ' + ownCompany.vatNumber}"></p>
+      </td>
+    </tr>
+  </table>
+  <table class="parties-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="left-cell">
+        <div class="address-block">
+          <p class="company-name" th:if="${client != null}" th:text="${client.name}"></p>
+          <p th:each="line : ${clientAddressLines}" th:text="${line}"></p>
+        </div>
+      </td>
+    </tr>
+  </table>
+  <p class="document-title" th:text="'Invoice # ' + ${invoice.invoiceNumber}"></p>
+  <table class="meta-table">
+    <thead>
+      <tr>
+        <th style="width: 20%;">Invoice date :</th>
+        <th style="width: 20%;">Delivery date :</th>
+        <th style="width: 20%;">Our ref. :</th>
+        <th style="width: 20%;">Your ref. :</th>
+        <th style="width: 20%;">Incoterm :</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td th:text="${invoice.invoiceDate != null ? #temporals.format(invoice.invoiceDate, 'dd/MM/yyyy') : ''}"></td>
+        <td th:text="${sale != null and sale.expectedDeliveryDate != null ? #temporals.format(sale.expectedDeliveryDate, 'dd/MM/yyyy') : ''}"></td>
+        <td th:text="${sale != null ? sale.saleNumber : ''}"></td>
+        <td th:text="${sale != null and sale.clientReference != null ? sale.clientReference : ''}"></td>
+        <td>
+          <p th:text="${incotermText}"></p>
+          <p th:if="${incotermLocation != null and !incotermLocation.isBlank()}" th:text="${incotermLocation}"></p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  <table class="lines-table">
+    <thead>
+      <tr>
+        <th style="width: 39%;">PRODUCT</th>
+        <th class="right" style="width: 15%;">Quantity</th>
+        <th class="right" style="width: 16%;">Unit price</th>
+        <th style="width: 10%;">Taxe</th>
+        <th class="right" style="width: 20%;">Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr th:each="line : ${lines}">
+        <td>
+          <p th:text="${line.displayName}"></p>
+          <p class="product-sub" th:if="${line.shortDescription != null}" th:text="${line.shortDescription}"></p>
+        </td>
+        <td class="right" th:text="${#numbers.formatDecimal(line.quantity, 1, 'WHITESPACE', 2, 'COMMA') + (line.unit != null ? ' ' + line.unit : '')}"></td>
+        <td class="right" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(line.unitPriceExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td>
+        <td th:text="${line.vatRate.signum() != 0 ? #numbers.formatDecimal(line.vatRate, 1, 'NONE', 0, 'COMMA') + '%' : ''}"></td>
+        <td class="right" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(line.lineTotalExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td>
+      </tr>
+    </tbody>
+  </table>
+  <table class="totals-table">
+    <tr><td>Total HT</td><td class="amount" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(invoice.totalExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td></tr>
+    <tr><td>TVA</td><td class="amount" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(invoice.totalVat, 1, 'WHITESPACE', 2, 'COMMA')}"></td></tr>
+    <tr class="final-row"><td>TOTAL TTC</td><td class="amount" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(invoice.totalInclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td></tr>
+  </table>
+  <div class="details-block">
+    <p class="detail-line" th:text="${'Payment term: ' + paymentTermLabel}"></p>
+    <div th:each="line : ${lines}">
+      <p class="detail-line"
+         th:text="${'PO: ' + customerReference
+                   + ' / '
+                   + incotermText
+                   + (incotermLocation != null and !incotermLocation.isBlank() ? ' - ' + incotermLocation : '')
+                   + (line.madeIn != null ? ' / Made in ' + line.madeIn : '')}"></p>
+      <p class="detail-line" th:text="${'HS Code: ' + (line.hsCode != null ? line.hsCode : '')}"></p>
+      <p class="detail-line" th:text="${'PC: ' + (line.clientProductCode != null ? line.clientProductCode : '')}"></p>
+    </div>
+    <p class="detail-line"
+       th:text="${(netstoneDeliveryNote != null and netstoneDeliveryNote.containerNumber != null ? netstoneDeliveryNote.containerNumber : '')
+                 + ' / Seals: '
+                 + (netstoneDeliveryNote != null and netstoneDeliveryNote.seals != null ? netstoneDeliveryNote.seals : '')
+                 + ' / LOT: '
+                 + (netstoneDeliveryNote != null and netstoneDeliveryNote.lot != null ? netstoneDeliveryNote.lot : '')}"></p>
+    <p class="detail-line" th:text="${'Fiscal Position Remark: ' + fiscalPositionRemark}"></p>
+  </div>
+</body>
+</html>

--- a/src/main/resources/templates/pdf/invoice-codig.html
+++ b/src/main/resources/templates/pdf/invoice-codig.html
@@ -107,22 +107,23 @@
   </table>
   <div class="details-block">
     <p class="detail-line" th:text="${'Payment term: ' + paymentTermLabel}"></p>
-    <div th:each="line : ${lines}">
-      <p class="detail-line"
-         th:text="${'PO: ' + customerReference
-                   + ' / '
-                   + incotermText
-                   + (incotermLocation != null and !incotermLocation.isBlank() ? ' - ' + incotermLocation : '')
-                   + (line.madeIn != null ? ' / Made in ' + line.madeIn : '')}"></p>
-      <p class="detail-line" th:text="${'HS Code: ' + (line.hsCode != null ? line.hsCode : '')}"></p>
-      <p class="detail-line" th:text="${'PC: ' + (line.clientProductCode != null ? line.clientProductCode : '')}"></p>
-    </div>
     <p class="detail-line"
-       th:text="${(netstoneDeliveryNote != null and netstoneDeliveryNote.containerNumber != null ? netstoneDeliveryNote.containerNumber : '')
+       th:text="${'PO: ' + customerReference
+                 + ' / '
+                 + incotermText
+                 + (incotermLocation != null and !incotermLocation.isBlank() ? ' - ' + incotermLocation : '')}"></p>
+    <p class="detail-line" th:each="line : ${lines}"
+       th:text="${(line.displayName != null ? line.displayName + ' — ' : '')
+                 + (line.madeIn != null ? 'Made in ' + line.madeIn : '')
+                 + (line.hsCode != null ? ' / HS Code: ' + line.hsCode : '')
+                 + (line.clientProductCode != null ? ' / PC: ' + line.clientProductCode : '')}"></p>
+    <p class="detail-line"
+       th:if="${netstoneDeliveryNote != null}"
+       th:text="${(netstoneDeliveryNote.containerNumber != null ? netstoneDeliveryNote.containerNumber : '')
                  + ' / Seals: '
-                 + (netstoneDeliveryNote != null and netstoneDeliveryNote.seals != null ? netstoneDeliveryNote.seals : '')
+                 + (netstoneDeliveryNote.seals != null ? netstoneDeliveryNote.seals : '')
                  + ' / LOT: '
-                 + (netstoneDeliveryNote != null and netstoneDeliveryNote.lot != null ? netstoneDeliveryNote.lot : '')}"></p>
+                 + (netstoneDeliveryNote.lot != null ? netstoneDeliveryNote.lot : '')}"></p>
     <p class="detail-line" th:text="${'Fiscal Position Remark: ' + fiscalPositionRemark}"></p>
   </div>
 </body>

--- a/src/main/resources/templates/pdf/invoice-netstone.html
+++ b/src/main/resources/templates/pdf/invoice-netstone.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <style>
+    body { font-family: Arial, Helvetica, sans-serif; font-size: 11pt; color: #333333; margin: 0; padding: 0; }
+    p { margin: 0; padding: 0; }
+    .header-table { width: 100%; margin-bottom: 28pt; }
+    .logo-cell { width: 58%; vertical-align: top; }
+    .logo-cell img { height: 80pt; max-width: 180pt; }
+    .addr-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .company-name { font-size: 12pt; font-weight: bold; margin-bottom: 4pt; }
+    .parties-table { width: 100%; margin-bottom: 24pt; }
+    .left-cell { width: 58%; vertical-align: top; font-size: 10pt; }
+    .right-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .block-label { font-weight: bold; margin-bottom: 4pt; }
+    .address-block { margin-bottom: 12pt; }
+    .document-title { color: #E07028; font-size: 24pt; font-weight: bold; margin-bottom: 16pt; }
+    .meta-table { width: 100%; border-collapse: collapse; margin-bottom: 20pt; }
+    .meta-table th { color: #E07028; font-size: 9pt; font-weight: bold; text-align: left; padding: 0 8pt 3pt 0; }
+    .meta-table td { font-size: 10pt; padding: 0 8pt 0 0; vertical-align: top; }
+    .lines-table { width: 100%; border-collapse: collapse; border-top: 3pt double #333333; border-bottom: 3pt double #333333; margin-bottom: 16pt; }
+    .lines-table th { padding: 7pt 8pt; font-size: 9pt; font-weight: bold; text-align: left; }
+    .lines-table th.right, .lines-table td.right { text-align: right; }
+    .lines-table td { padding: 7pt 8pt; font-size: 10pt; vertical-align: top; }
+    .product-sub { font-size: 9pt; color: #666666; margin-top: 3pt; }
+    .totals-table { width: 220pt; margin-left: auto; border-collapse: collapse; }
+    .totals-table td { padding: 4pt 4pt; font-size: 10pt; }
+    .totals-table .amount { text-align: right; }
+    .totals-table .final-row td { border-top: 2pt solid #333333; color: #E07028; font-weight: bold; font-size: 12pt; }
+    @page { margin: 18mm 18mm 22mm 18mm; @bottom-right { content: counter(page); font-size: 9pt; color: #777777; } }
+  </style>
+</head>
+<body>
+  <table class="header-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="logo-cell"><img th:if="${logoSrc != null}" th:src="${logoSrc}" alt=""/></td>
+      <td class="addr-cell" th:if="${ownCompany != null}">
+        <p class="company-name" th:text="${ownCompany.name}"></p>
+        <p th:each="line : ${ownCompanyAddressLines}" th:text="${line}"></p>
+      </td>
+    </tr>
+  </table>
+  <table class="parties-table" cellspacing="0" cellpadding="0">
+    <tr>
+      <td class="left-cell">
+        <div class="address-block">
+          <p class="block-label">INVOICING ADDRESS :</p>
+          <p th:each="line : ${invoicingAddressLines}" th:text="${line}"></p>
+        </div>
+      </td>
+      <td class="right-cell" th:if="${client != null}">
+        <p class="company-name" th:text="${client.name}"></p>
+        <p th:each="line : ${clientAddressLines}" th:text="${line}"></p>
+      </td>
+    </tr>
+  </table>
+  <p class="document-title" th:text="'Invoice # ' + ${invoice.internalInvoiceNumber}"></p>
+  <table class="meta-table">
+    <thead>
+      <tr>
+        <th style="width: 25%;">Customer ref. :</th>
+        <th style="width: 25%;">Invoice date :</th>
+        <th style="width: 25%;">Due date :</th>
+        <th style="width: 25%;">Incoterm :</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td th:text="${customerReference}"></td>
+        <td th:text="${invoice.invoiceDate != null ? #temporals.format(invoice.invoiceDate, 'dd/MM/yyyy') : ''}"></td>
+        <td th:text="${invoice.dueDate != null ? #temporals.format(invoice.dueDate, 'dd/MM/yyyy') : ''}"></td>
+        <td th:text="${incotermText}"></td>
+      </tr>
+    </tbody>
+  </table>
+  <table class="lines-table">
+    <thead>
+      <tr>
+        <th style="width: 39%;">PRODUCT</th>
+        <th class="right" style="width: 15%;">Quantity</th>
+        <th class="right" style="width: 16%;">Unit price</th>
+        <th style="width: 10%;">Taxe</th>
+        <th class="right" style="width: 20%;">Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr th:each="line : ${lines}">
+        <td>
+          <p th:text="${line.displayName}"></p>
+          <p class="product-sub" th:if="${line.shortDescription != null}" th:text="${line.shortDescription}"></p>
+        </td>
+        <td class="right" th:text="${#numbers.formatDecimal(line.quantity, 1, 'WHITESPACE', 2, 'COMMA') + (line.unit != null ? ' ' + line.unit : '')}"></td>
+        <td class="right" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(line.unitPriceExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td>
+        <td th:text="${line.vatRate.signum() != 0 ? #numbers.formatDecimal(line.vatRate, 1, 'NONE', 0, 'COMMA') + '%' : ''}"></td>
+        <td class="right" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(line.lineTotalExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td>
+      </tr>
+    </tbody>
+  </table>
+  <table class="totals-table">
+    <tr><td>Total HT</td><td class="amount" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(invoice.totalExclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td></tr>
+    <tr><td>TVA</td><td class="amount" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(invoice.totalVat, 1, 'WHITESPACE', 2, 'COMMA')}"></td></tr>
+    <tr class="final-row"><td>TOTAL TTC</td><td class="amount" th:text="${currencySymbol + ' ' + #numbers.formatDecimal(invoice.totalInclTax, 1, 'WHITESPACE', 2, 'COMMA')}"></td></tr>
+  </table>
+</body>
+</html>

--- a/src/test/kotlin/fr/axl/lvy/base/NumberSequenceServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/base/NumberSequenceServiceTest.kt
@@ -84,4 +84,58 @@ class NumberSequenceServiceTest {
       }
       .isInstanceOf(IllegalArgumentException::class.java)
   }
+
+  @Test
+  fun nextNumberForYear_uses_year_in_prefix_and_resets_per_year() {
+    val first2026 =
+      numberSequenceService.nextNumberForYear(NumberSequenceService.INVOICE_CODIG, 2026)
+    val second2026 =
+      numberSequenceService.nextNumberForYear(NumberSequenceService.INVOICE_CODIG, 2026)
+    val first2027 =
+      numberSequenceService.nextNumberForYear(NumberSequenceService.INVOICE_CODIG, 2027)
+
+    assertThat(first2026).isEqualTo("CoD_INV/2026/001")
+    assertThat(second2026).isEqualTo("CoD_INV/2026/002")
+    // The 2027 counter is independent — starts back at 001.
+    assertThat(first2027).isEqualTo("CoD_INV/2027/001")
+  }
+
+  @Test
+  fun nextNumberForYear_isolated_per_base_entity_type() {
+    val codig = numberSequenceService.nextNumberForYear(NumberSequenceService.INVOICE_CODIG, 2026)
+    val netstone =
+      numberSequenceService.nextNumberForYear(NumberSequenceService.INVOICE_NETSTONE, 2026)
+
+    assertThat(codig).isEqualTo("CoD_INV/2026/001")
+    assertThat(netstone).isEqualTo("NST_INV/2026/001")
+  }
+
+  @Test
+  fun previewNextNumberForYear_does_not_advance_sequence() {
+    val preview =
+      numberSequenceService.previewNextNumberForYear(NumberSequenceService.INVOICE_NETSTONE, 2026)
+    val next = numberSequenceService.nextNumberForYear(NumberSequenceService.INVOICE_NETSTONE, 2026)
+    val secondPreview =
+      numberSequenceService.previewNextNumberForYear(NumberSequenceService.INVOICE_NETSTONE, 2026)
+
+    assertThat(preview).isEqualTo("NST_INV/2026/001")
+    assertThat(next).isEqualTo(preview)
+    assertThat(secondPreview).isEqualTo("NST_INV/2026/002")
+  }
+
+  @Test
+  fun nextNumberForYear_throws_for_unknown_base_type() {
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+        numberSequenceService.nextNumberForYear("NO_SUCH_TYPE", 2026)
+      }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  @Test
+  fun previewNextNumberForYear_throws_for_unknown_base_type() {
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+        numberSequenceService.previewNextNumberForYear("NO_SUCH_TYPE", 2026)
+      }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
 }

--- a/src/test/kotlin/fr/axl/lvy/invoice/InvoiceCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/invoice/InvoiceCodigServiceTest.kt
@@ -3,6 +3,7 @@ package fr.axl.lvy.invoice
 import fr.axl.lvy.TestDataFactory
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.delivery.DeliveryNoteCodigRepository
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigRepository
@@ -28,6 +29,7 @@ class InvoiceCodigServiceTest {
   @Autowired lateinit var orderCodigRepository: OrderCodigRepository
   @Autowired lateinit var salesCodigRepository: SalesCodigRepository
   @Autowired lateinit var clientService: ClientService
+  @Autowired lateinit var deliveryNoteCodigRepository: DeliveryNoteCodigRepository
   @Autowired lateinit var testData: TestDataFactory
 
   @BeforeEach
@@ -284,6 +286,71 @@ class InvoiceCodigServiceTest {
     val found = invoiceCodigService.findByOrderCodigId(order.id!!)
 
     assertThat(found?.id).isEqualTo(second.id)
+  }
+
+  @Test
+  fun saveWithLines_preserves_existing_client_snapshot_fields() {
+    val (sale, order) = createSaleAndOrder("SNAP1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.clientName = "Snapshot Name"
+    invoice.clientAddress = "Snapshot Address"
+    invoice.clientSiret = "99999999999999"
+    invoice.clientVatNumber = "FR99SNAP"
+
+    val saved = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.clientName).isEqualTo("Snapshot Name")
+    assertThat(saved.clientAddress).isEqualTo("Snapshot Address")
+    assertThat(saved.clientSiret).isEqualTo("99999999999999")
+    assertThat(saved.clientVatNumber).isEqualTo("FR99SNAP")
+  }
+
+  @Test
+  fun saveWithLines_falls_back_to_client_billing_when_order_has_none() {
+    val client = testData.createClient("CLI-IC-FB1", "Client Bill\n75001 Paris", "1 Ship St")
+    val order = OrderCodig("PO-IC-FB1", client, LocalDate.of(2026, 3, 1))
+    order.status = OrderCodig.OrderCodigStatus.DELIVERED
+    // Intentionally no billingAddress on the order.
+    val savedOrder = orderCodigRepository.save(order)
+
+    val invoice = InvoiceCodig("", client, LocalDate.of(2026, 5, 1))
+    invoice.orderCodig = savedOrder
+    invoice.status = InvoiceCodig.InvoiceCodigStatus.DRAFT
+
+    val saved = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.clientAddress).isEqualTo("Client Bill\n75001 Paris")
+  }
+
+  @Test
+  fun saveWithLines_uses_order_delivery_note_when_invoice_has_none() {
+    val (sale, order) = createSaleAndOrder("DN1")
+    val deliveryNote = fr.axl.lvy.delivery.DeliveryNoteCodig("DN-IC-DN1", order, order.client)
+    deliveryNoteCodigRepository.save(deliveryNote)
+    order.deliveryNote = deliveryNote
+    orderCodigRepository.saveAndFlush(order)
+
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.deliveryNote = null
+
+    val saved = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.deliveryNote?.id).isEqualTo(deliveryNote.id)
+  }
+
+  @Test
+  fun saveWithLines_does_not_demote_order_status_below_invoiced() {
+    val (sale, order) = createSaleAndOrder("DEMO1", OrderCodig.OrderCodigStatus.INVOICED)
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.status = InvoiceCodig.InvoiceCodigStatus.PAID
+
+    invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    val reloaded = orderCodigRepository.findById(order.id!!).orElseThrow()
+    assertThat(reloaded.status).isEqualTo(OrderCodig.OrderCodigStatus.INVOICED)
   }
 
   @Test

--- a/src/test/kotlin/fr/axl/lvy/invoice/InvoiceCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/invoice/InvoiceCodigServiceTest.kt
@@ -1,0 +1,300 @@
+package fr.axl.lvy.invoice
+
+import fr.axl.lvy.TestDataFactory
+import fr.axl.lvy.client.Client
+import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.order.OrderCodig
+import fr.axl.lvy.order.OrderCodigRepository
+import fr.axl.lvy.sale.SalesCodig
+import fr.axl.lvy.sale.SalesCodigRepository
+import fr.axl.lvy.user.User
+import java.math.BigDecimal
+import java.time.LocalDate
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class InvoiceCodigServiceTest {
+
+  @Autowired lateinit var invoiceCodigService: InvoiceCodigService
+  @Autowired lateinit var invoiceCodigRepository: InvoiceCodigRepository
+  @Autowired lateinit var orderCodigRepository: OrderCodigRepository
+  @Autowired lateinit var salesCodigRepository: SalesCodigRepository
+  @Autowired lateinit var clientService: ClientService
+  @Autowired lateinit var testData: TestDataFactory
+
+  @BeforeEach
+  fun ensureOwnCompanies() {
+    if (clientService.findDefaultCodigCompany().isEmpty) {
+      val codig = Client("CLI-IC-OWN-COD", "Codig")
+      codig.type = Client.ClientType.OWN_COMPANY
+      codig.role = Client.ClientRole.OWN_COMPANY
+      codig.visibleCompany = User.Company.CODIG
+      clientService.save(codig)
+    }
+  }
+
+  private fun createSaleAndOrder(
+    suffix: String,
+    orderStatus: OrderCodig.OrderCodigStatus = OrderCodig.OrderCodigStatus.DELIVERED,
+  ): Pair<SalesCodig, OrderCodig> {
+    val client = testData.createClient("CLI-IC-$suffix", "1 Bill St", "1 Ship St")
+    val order = OrderCodig("PO-IC-$suffix", client, LocalDate.of(2026, 3, 1))
+    order.status = orderStatus
+    order.billingAddress = "Order Bill\n75001 Paris"
+    val savedOrder = orderCodigRepository.save(order)
+
+    val sale = SalesCodig("SO-IC-$suffix", client, LocalDate.of(2026, 3, 5))
+    sale.orderCodig = savedOrder
+    sale.expectedDeliveryDate = LocalDate.of(2026, 4, 5)
+    sale.currency = "EUR"
+    sale.incoterms = "FOB"
+    val savedSale = salesCodigRepository.save(sale)
+    return savedSale to savedOrder
+  }
+
+  @Test
+  fun prepareForSale_returns_existing_invoice_when_already_linked() {
+    val (sale, order) = createSaleAndOrder("PFS1")
+    val existing = InvoiceCodig("FA-EXIST-01", sale.client, LocalDate.of(2026, 3, 10))
+    existing.orderCodig = order
+    invoiceCodigRepository.saveAndFlush(existing)
+
+    val prepared = invoiceCodigService.prepareForSale(sale, order)
+
+    assertThat(prepared.id).isEqualTo(existing.id)
+    assertThat(prepared.invoiceNumber).isEqualTo("FA-EXIST-01")
+  }
+
+  @Test
+  fun prepareForSale_returns_draft_when_no_invoice_exists() {
+    val (sale, order) = createSaleAndOrder("PFS2")
+
+    val prepared = invoiceCodigService.prepareForSale(sale, order)
+
+    assertThat(prepared.id).isNull()
+    assertThat(prepared.invoiceNumber).isBlank()
+    assertThat(prepared.client.id).isEqualTo(sale.client.id)
+    assertThat(prepared.orderCodig?.id).isEqualTo(order.id)
+    assertThat(prepared.dueDate).isEqualTo(sale.expectedDeliveryDate)
+    assertThat(prepared.currency).isEqualTo(sale.currency)
+    assertThat(prepared.incoterms).isEqualTo(sale.incoterms)
+  }
+
+  @Test
+  fun saveWithLines_allocates_year_scoped_invoice_number_for_new_invoice() {
+    val (sale, order) = createSaleAndOrder("NUM1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+
+    val saved = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.invoiceNumber).startsWith("CoD_INV/2026/")
+  }
+
+  @Test
+  fun saveWithLines_recalculates_totals_from_lines() {
+    val (sale, order) = createSaleAndOrder("TOT1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+
+    val line = DocumentLine(DocumentLine.DocumentType.INVOICE_CODIG, 0L, "Item")
+    line.quantity = BigDecimal("2")
+    line.unitPriceExclTax = BigDecimal("100.00")
+    line.discountPercent = BigDecimal.ZERO
+    line.vatRate = BigDecimal("20.00")
+
+    val saved = invoiceCodigService.saveWithLines(invoice, listOf(line))
+
+    assertThat(saved.totalExclTax).isEqualByComparingTo("200.00")
+    assertThat(saved.totalVat).isEqualByComparingTo("40.00")
+    assertThat(saved.totalInclTax).isEqualByComparingTo("240.00")
+  }
+
+  @Test
+  fun saveWithLines_replaces_existing_lines_on_update() {
+    val (sale, order) = createSaleAndOrder("REP1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+
+    val line1 = DocumentLine(DocumentLine.DocumentType.INVOICE_CODIG, 0L, "First")
+    line1.quantity = BigDecimal.ONE
+    line1.unitPriceExclTax = BigDecimal("50.00")
+    line1.discountPercent = BigDecimal.ZERO
+    line1.vatRate = BigDecimal("20.00")
+    val firstSave = invoiceCodigService.saveWithLines(invoice, listOf(line1))
+
+    val line2 = DocumentLine(DocumentLine.DocumentType.INVOICE_CODIG, 0L, "Second")
+    line2.quantity = BigDecimal("3")
+    line2.unitPriceExclTax = BigDecimal("10.00")
+    line2.discountPercent = BigDecimal.ZERO
+    line2.vatRate = BigDecimal("5.50")
+    val secondSave = invoiceCodigService.saveWithLines(firstSave, listOf(line2))
+
+    val lines = invoiceCodigService.findLines(secondSave.id!!)
+    assertThat(lines).hasSize(1)
+    assertThat(lines[0].designation).isEqualTo("Second")
+    assertThat(secondSave.totalExclTax).isEqualByComparingTo("30.00")
+  }
+
+  @Test
+  fun saveWithLines_does_not_advance_invoice_number_on_update() {
+    val (sale, order) = createSaleAndOrder("REP2")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    val first = invoiceCodigService.saveWithLines(invoice, emptyList())
+    val originalNumber = first.invoiceNumber
+
+    val second = invoiceCodigService.saveWithLines(first, emptyList())
+
+    assertThat(second.invoiceNumber).isEqualTo(originalNumber)
+  }
+
+  @Test
+  fun saveWithLines_keeps_order_status_when_invoice_is_draft() {
+    val (sale, order) = createSaleAndOrder("DR1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.status = InvoiceCodig.InvoiceCodigStatus.DRAFT
+
+    invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    val reloaded = orderCodigRepository.findById(order.id!!).orElseThrow()
+    assertThat(reloaded.status).isEqualTo(OrderCodig.OrderCodigStatus.DELIVERED)
+  }
+
+  @Test
+  fun saveWithLines_advances_order_status_to_invoiced_when_invoice_validated() {
+    val (sale, order) = createSaleAndOrder("VAL1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.status = InvoiceCodig.InvoiceCodigStatus.ISSUED
+
+    invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    val reloaded = orderCodigRepository.findById(order.id!!).orElseThrow()
+    assertThat(reloaded.status).isEqualTo(OrderCodig.OrderCodigStatus.INVOICED)
+  }
+
+  @Test
+  fun saveWithLines_preserves_paid_status_on_update() {
+    val (sale, order) = createSaleAndOrder("PAID1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.status = InvoiceCodig.InvoiceCodigStatus.ISSUED
+    val firstSave = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    firstSave.status = InvoiceCodig.InvoiceCodigStatus.PAID
+    val updated = invoiceCodigService.saveWithLines(firstSave, emptyList())
+
+    assertThat(updated.status).isEqualTo(InvoiceCodig.InvoiceCodigStatus.PAID)
+    val reloaded = invoiceCodigRepository.findById(updated.id!!).orElseThrow()
+    assertThat(reloaded.status).isEqualTo(InvoiceCodig.InvoiceCodigStatus.PAID)
+  }
+
+  @Test
+  fun saveWithLines_throws_when_order_codig_missing() {
+    val client = testData.createClient("CLI-IC-NOORD")
+    val invoice = InvoiceCodig("", client, LocalDate.of(2026, 3, 1))
+    // Intentionally do not link orderCodig.
+
+    assertThatThrownBy { invoiceCodigService.saveWithLines(invoice, emptyList()) }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("rattachée à une commande")
+  }
+
+  @Test
+  fun saveWithLines_links_order_invoice_back_reference() {
+    val (sale, order) = createSaleAndOrder("LINK1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoice.status = InvoiceCodig.InvoiceCodigStatus.ISSUED
+
+    val saved = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    val reloaded = orderCodigRepository.findById(order.id!!).orElseThrow()
+    assertThat(reloaded.invoice?.id).isEqualTo(saved.id)
+  }
+
+  @Test
+  fun findByOrderCodigId_returns_invoice() {
+    val (sale, order) = createSaleAndOrder("FBO1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    val found = invoiceCodigService.findByOrderCodigId(order.id!!)
+
+    assertThat(found).isNotNull
+    assertThat(found!!.orderCodig?.id).isEqualTo(order.id)
+  }
+
+  @Test
+  fun findByOrderCodigId_returns_null_when_no_invoice() {
+    val (_, order) = createSaleAndOrder("FBO2")
+
+    assertThat(invoiceCodigService.findByOrderCodigId(order.id!!)).isNull()
+  }
+
+  @Test
+  fun findById_returns_invoice() {
+    val (sale, order) = createSaleAndOrder("FBI1")
+    val invoice = invoiceCodigService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 5, 12)
+    val saved = invoiceCodigService.saveWithLines(invoice, emptyList())
+
+    val found = invoiceCodigService.findById(saved.id!!)
+
+    assertThat(found).isPresent
+    assertThat(found.get().invoiceNumber).isEqualTo(saved.invoiceNumber)
+  }
+
+  @Test
+  fun findById_returns_empty_when_unknown() {
+    assertThat(invoiceCodigService.findById(-1L)).isEmpty
+  }
+
+  @Test
+  fun previewNextInvoiceNumber_does_not_advance_real_sequence() {
+    val date = LocalDate.of(2026, 6, 1)
+    val preview1 = invoiceCodigService.previewNextInvoiceNumber(date)
+    val preview2 = invoiceCodigService.previewNextInvoiceNumber(date)
+
+    assertThat(preview1).isEqualTo(preview2)
+    assertThat(preview1).startsWith("CoD_INV/2026/")
+  }
+
+  @Test
+  fun findByOrderCodigId_returns_latest_when_multiple_invoices_exist() {
+    val (_, order) = createSaleAndOrder("MULTI1")
+    val first = InvoiceCodig("FA-MULTI-01", order.client, LocalDate.of(2026, 3, 1))
+    first.orderCodig = order
+    invoiceCodigRepository.saveAndFlush(first)
+    val second = InvoiceCodig("FA-MULTI-02", order.client, LocalDate.of(2026, 4, 1))
+    second.orderCodig = order
+    invoiceCodigRepository.saveAndFlush(second)
+
+    val found = invoiceCodigService.findByOrderCodigId(order.id!!)
+
+    assertThat(found?.id).isEqualTo(second.id)
+  }
+
+  @Test
+  fun findByOrderCodigId_excludes_soft_deleted() {
+    val (_, order) = createSaleAndOrder("SD1")
+    val invoice = InvoiceCodig("FA-SD-01", order.client, LocalDate.of(2026, 3, 1))
+    invoice.orderCodig = order
+    invoiceCodigRepository.saveAndFlush(invoice)
+    invoice.softDelete()
+    invoiceCodigRepository.saveAndFlush(invoice)
+
+    assertThat(invoiceCodigService.findByOrderCodigId(order.id!!)).isNull()
+  }
+}

--- a/src/test/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneServiceTest.kt
@@ -1,0 +1,351 @@
+package fr.axl.lvy.invoice
+
+import fr.axl.lvy.TestDataFactory
+import fr.axl.lvy.client.Client
+import fr.axl.lvy.client.ClientService
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.order.OrderCodig
+import fr.axl.lvy.order.OrderCodigRepository
+import fr.axl.lvy.order.OrderNetstone
+import fr.axl.lvy.order.OrderNetstoneRepository
+import fr.axl.lvy.sale.SalesCodig
+import fr.axl.lvy.sale.SalesCodigRepository
+import fr.axl.lvy.sale.SalesNetstone
+import fr.axl.lvy.sale.SalesNetstoneRepository
+import fr.axl.lvy.user.User
+import java.math.BigDecimal
+import java.time.LocalDate
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@Transactional
+class InvoiceNetstoneServiceTest {
+
+  @Autowired lateinit var invoiceNetstoneService: InvoiceNetstoneService
+  @Autowired lateinit var invoiceNetstoneRepository: InvoiceNetstoneRepository
+  @Autowired lateinit var orderCodigRepository: OrderCodigRepository
+  @Autowired lateinit var orderNetstoneRepository: OrderNetstoneRepository
+  @Autowired lateinit var salesCodigRepository: SalesCodigRepository
+  @Autowired lateinit var salesNetstoneRepository: SalesNetstoneRepository
+  @Autowired lateinit var clientService: ClientService
+  @Autowired lateinit var testData: TestDataFactory
+
+  @BeforeEach
+  fun ensureOwnCompanies() {
+    if (clientService.findDefaultCodigCompany().isEmpty) {
+      val codig = Client("CLI-IN-OWN-COD", "Codig")
+      codig.type = Client.ClientType.OWN_COMPANY
+      codig.role = Client.ClientRole.OWN_COMPANY
+      codig.visibleCompany = User.Company.CODIG
+      codig.billingAddress = "Codig Bill\n75001 Paris"
+      clientService.save(codig)
+    }
+    if (clientService.findDefaultCodigSupplier().isEmpty) {
+      val supplier = Client("CLI-IN-OWN-NET", "Netstone")
+      supplier.type = Client.ClientType.OWN_COMPANY
+      supplier.role = Client.ClientRole.OWN_COMPANY
+      supplier.visibleCompany = User.Company.NETSTONE
+      clientService.save(supplier)
+    }
+  }
+
+  private fun createSaleAndOrder(suffix: String): Triple<SalesNetstone, OrderNetstone, SalesCodig> {
+    val client = testData.createClient("CLI-IN-$suffix", "1 Bill St", "1 Ship St")
+    val orderCodig = OrderCodig("PO-IN-$suffix", client, LocalDate.of(2026, 3, 1))
+    orderCodig.status = OrderCodig.OrderCodigStatus.DELIVERED
+    orderCodigRepository.save(orderCodig)
+
+    val orderNetstone = OrderNetstone("PON-IN-$suffix", orderCodig)
+    orderNetstone.orderDate = LocalDate.of(2026, 3, 2)
+    orderNetstone.status = OrderNetstone.OrderNetstoneStatus.RECEIVED
+    val savedOrderNetstone = orderNetstoneRepository.save(orderNetstone)
+
+    val salesCodig = SalesCodig("SO-IN-$suffix", client, LocalDate.of(2026, 3, 5))
+    salesCodig.orderCodig = orderCodig
+    val savedSalesCodig = salesCodigRepository.save(salesCodig)
+
+    val salesNetstone = SalesNetstone("SON-IN-$suffix", savedSalesCodig)
+    salesNetstone.orderNetstone = savedOrderNetstone
+    salesNetstone.saleDate = LocalDate.of(2026, 3, 6)
+    salesNetstone.expectedDeliveryDate = LocalDate.of(2026, 4, 10)
+    salesNetstone.notes = "from-sale"
+    val savedSalesNetstone = salesNetstoneRepository.save(salesNetstone)
+    return Triple(savedSalesNetstone, savedOrderNetstone, savedSalesCodig)
+  }
+
+  @Test
+  fun prepareForSale_returns_existing_invoice_when_already_linked() {
+    val (sale, order, _) = createSaleAndOrder("PFS1")
+    val codig = clientService.findDefaultCodigCompany().orElseThrow()
+    val existing =
+      InvoiceNetstone(
+        "FN-EXIST-01",
+        InvoiceNetstone.RecipientType.COMPANY_CODIG,
+        codig,
+        LocalDate.of(2026, 3, 10),
+      )
+    existing.orderNetstone = order
+    invoiceNetstoneRepository.saveAndFlush(existing)
+
+    val prepared = invoiceNetstoneService.prepareForSale(sale, order)
+
+    assertThat(prepared.id).isEqualTo(existing.id)
+    assertThat(prepared.internalInvoiceNumber).isEqualTo("FN-EXIST-01")
+  }
+
+  @Test
+  fun prepareForSale_creates_draft_when_no_invoice_exists() {
+    val (sale, order, _) = createSaleAndOrder("PFS2")
+
+    val prepared = invoiceNetstoneService.prepareForSale(sale, order)
+
+    assertThat(prepared.id).isNull()
+    assertThat(prepared.internalInvoiceNumber).isBlank()
+    assertThat(prepared.recipientType).isEqualTo(InvoiceNetstone.RecipientType.COMPANY_CODIG)
+    assertThat(prepared.orderNetstone?.id).isEqualTo(order.id)
+    assertThat(prepared.dueDate).isEqualTo(sale.expectedDeliveryDate)
+    assertThat(prepared.notes).isEqualTo("from-sale")
+    assertThat(prepared.billingAddress).isEqualTo("Codig Bill\n75001 Paris")
+  }
+
+  @Test
+  fun saveWithLines_allocates_year_scoped_invoice_number_for_new_invoice() {
+    val (sale, order, _) = createSaleAndOrder("NUM1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.internalInvoiceNumber).startsWith("NST_INV/2026/")
+  }
+
+  @Test
+  fun saveWithLines_recalculates_totals_from_lines() {
+    val (sale, order, _) = createSaleAndOrder("TOT1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+
+    val line = DocumentLine(DocumentLine.DocumentType.INVOICE_NETSTONE, 0L, "Item")
+    line.quantity = BigDecimal("4")
+    line.unitPriceExclTax = BigDecimal("25.00")
+    line.discountPercent = BigDecimal.ZERO
+    line.vatRate = BigDecimal("20.00")
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, listOf(line))
+
+    assertThat(saved.totalExclTax).isEqualByComparingTo("100.00")
+    assertThat(saved.totalVat).isEqualByComparingTo("20.00")
+    assertThat(saved.totalInclTax).isEqualByComparingTo("120.00")
+  }
+
+  @Test
+  fun saveWithLines_preserves_supplier_invoice_number() {
+    val (sale, order, _) = createSaleAndOrder("SIN1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    invoice.supplierInvoiceNumber = "SUPPLIER-12345"
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.supplierInvoiceNumber).isEqualTo("SUPPLIER-12345")
+    val reloaded = invoiceNetstoneRepository.findById(saved.id!!).orElseThrow()
+    assertThat(reloaded.supplierInvoiceNumber).isEqualTo("SUPPLIER-12345")
+  }
+
+  @Test
+  fun saveWithLines_preserves_paid_status_on_update() {
+    val (sale, order, _) = createSaleAndOrder("PAID1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    invoice.status = InvoiceNetstone.InvoiceNetstoneStatus.VERIFIED
+    val firstSave = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    firstSave.status = InvoiceNetstone.InvoiceNetstoneStatus.PAID
+    val updated = invoiceNetstoneService.saveWithLines(firstSave, emptyList())
+
+    assertThat(updated.status).isEqualTo(InvoiceNetstone.InvoiceNetstoneStatus.PAID)
+    val reloaded = invoiceNetstoneRepository.findById(updated.id!!).orElseThrow()
+    assertThat(reloaded.status).isEqualTo(InvoiceNetstone.InvoiceNetstoneStatus.PAID)
+  }
+
+  @Test
+  fun saveWithLines_preserves_disputed_status_on_update() {
+    val (sale, order, _) = createSaleAndOrder("DISP1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    val firstSave = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    firstSave.status = InvoiceNetstone.InvoiceNetstoneStatus.DISPUTED
+    val updated = invoiceNetstoneService.saveWithLines(firstSave, emptyList())
+
+    assertThat(updated.status).isEqualTo(InvoiceNetstone.InvoiceNetstoneStatus.DISPUTED)
+  }
+
+  @Test
+  fun saveWithLines_throws_when_order_netstone_missing() {
+    val codig = clientService.findDefaultCodigCompany().orElseThrow()
+    val invoice =
+      InvoiceNetstone(
+        "",
+        InvoiceNetstone.RecipientType.COMPANY_CODIG,
+        codig,
+        LocalDate.of(2026, 3, 1),
+      )
+    // Intentionally do not link orderNetstone.
+
+    assertThatThrownBy { invoiceNetstoneService.saveWithLines(invoice, emptyList()) }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("rattachée à une commande")
+  }
+
+  @Test
+  fun saveWithLines_links_order_invoice_back_reference() {
+    val (sale, order, _) = createSaleAndOrder("LINK1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    val reloaded = orderNetstoneRepository.findById(order.id!!).orElseThrow()
+    assertThat(reloaded.invoiceNetstone?.id).isEqualTo(saved.id)
+  }
+
+  @Test
+  fun saveWithLines_replaces_existing_lines_on_update() {
+    val (sale, order, _) = createSaleAndOrder("REP1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+
+    val line1 = DocumentLine(DocumentLine.DocumentType.INVOICE_NETSTONE, 0L, "First")
+    line1.quantity = BigDecimal.ONE
+    line1.unitPriceExclTax = BigDecimal("50.00")
+    line1.discountPercent = BigDecimal.ZERO
+    line1.vatRate = BigDecimal("20.00")
+    val firstSave = invoiceNetstoneService.saveWithLines(invoice, listOf(line1))
+
+    val line2 = DocumentLine(DocumentLine.DocumentType.INVOICE_NETSTONE, 0L, "Second")
+    line2.quantity = BigDecimal("2")
+    line2.unitPriceExclTax = BigDecimal("10.00")
+    line2.discountPercent = BigDecimal.ZERO
+    line2.vatRate = BigDecimal("0.00")
+    val secondSave = invoiceNetstoneService.saveWithLines(firstSave, listOf(line2))
+
+    val lines = invoiceNetstoneService.findLines(secondSave.id!!)
+    assertThat(lines).hasSize(1)
+    assertThat(lines[0].designation).isEqualTo("Second")
+  }
+
+  @Test
+  fun saveWithLines_does_not_advance_invoice_number_on_update() {
+    val (sale, order, _) = createSaleAndOrder("NUM2")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    val first = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+    val originalNumber = first.internalInvoiceNumber
+
+    val second = invoiceNetstoneService.saveWithLines(first, emptyList())
+
+    assertThat(second.internalInvoiceNumber).isEqualTo(originalNumber)
+  }
+
+  @Test
+  fun findByOrderNetstoneId_returns_invoice() {
+    val (sale, order, _) = createSaleAndOrder("FBO1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    val found = invoiceNetstoneService.findByOrderNetstoneId(order.id!!)
+
+    assertThat(found).isNotNull
+    assertThat(found!!.orderNetstone?.id).isEqualTo(order.id)
+  }
+
+  @Test
+  fun findByOrderNetstoneId_returns_null_when_no_invoice() {
+    val (_, order, _) = createSaleAndOrder("FBO2")
+
+    assertThat(invoiceNetstoneService.findByOrderNetstoneId(order.id!!)).isNull()
+  }
+
+  @Test
+  fun findById_returns_invoice() {
+    val (sale, order, _) = createSaleAndOrder("FBI1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    val saved = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    val found = invoiceNetstoneService.findById(saved.id!!)
+
+    assertThat(found).isPresent
+    assertThat(found.get().internalInvoiceNumber).isEqualTo(saved.internalInvoiceNumber)
+  }
+
+  @Test
+  fun findById_returns_empty_when_unknown() {
+    assertThat(invoiceNetstoneService.findById(-1L)).isEmpty
+  }
+
+  @Test
+  fun previewNextInvoiceNumber_does_not_advance_real_sequence() {
+    val date = LocalDate.of(2026, 8, 1)
+    val preview1 = invoiceNetstoneService.previewNextInvoiceNumber(date)
+    val preview2 = invoiceNetstoneService.previewNextInvoiceNumber(date)
+
+    assertThat(preview1).isEqualTo(preview2)
+    assertThat(preview1).startsWith("NST_INV/2026/")
+  }
+
+  @Test
+  fun findByOrderNetstoneId_returns_latest_when_multiple_invoices_exist() {
+    val (_, order, _) = createSaleAndOrder("MULTI1")
+    val codig = clientService.findDefaultCodigCompany().orElseThrow()
+    val first =
+      InvoiceNetstone(
+        "FN-MULTI-01",
+        InvoiceNetstone.RecipientType.COMPANY_CODIG,
+        codig,
+        LocalDate.of(2026, 3, 1),
+      )
+    first.orderNetstone = order
+    invoiceNetstoneRepository.saveAndFlush(first)
+    val second =
+      InvoiceNetstone(
+        "FN-MULTI-02",
+        InvoiceNetstone.RecipientType.COMPANY_CODIG,
+        codig,
+        LocalDate.of(2026, 4, 1),
+      )
+    second.orderNetstone = order
+    invoiceNetstoneRepository.saveAndFlush(second)
+
+    val found = invoiceNetstoneService.findByOrderNetstoneId(order.id!!)
+
+    assertThat(found?.id).isEqualTo(second.id)
+  }
+
+  @Test
+  fun findByOrderNetstoneId_excludes_soft_deleted() {
+    val (_, order, _) = createSaleAndOrder("SD1")
+    val codig = clientService.findDefaultCodigCompany().orElseThrow()
+    val invoice =
+      InvoiceNetstone(
+        "FN-SD-01",
+        InvoiceNetstone.RecipientType.COMPANY_CODIG,
+        codig,
+        LocalDate.of(2026, 3, 1),
+      )
+    invoice.orderNetstone = order
+    invoiceNetstoneRepository.saveAndFlush(invoice)
+    invoice.softDelete()
+    invoiceNetstoneRepository.saveAndFlush(invoice)
+
+    assertThat(invoiceNetstoneService.findByOrderNetstoneId(order.id!!)).isNull()
+  }
+}

--- a/src/test/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/invoice/InvoiceNetstoneServiceTest.kt
@@ -331,6 +331,50 @@ class InvoiceNetstoneServiceTest {
   }
 
   @Test
+  fun saveWithLines_preserves_existing_billing_address() {
+    val (sale, order, _) = createSaleAndOrder("BILL1")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    invoice.billingAddress = "Custom Bill Address\n75001 Paris"
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.billingAddress).isEqualTo("Custom Bill Address\n75001 Paris")
+  }
+
+  @Test
+  fun saveWithLines_with_external_recipient_does_not_overwrite_recipient() {
+    val (sale, order, _) = createSaleAndOrder("EXT1")
+    val externalRecipient = testData.createClient("CLI-IN-EXT", "External Bill\n8000 Brussels", "x")
+    val invoice =
+      InvoiceNetstone(
+        "",
+        InvoiceNetstone.RecipientType.PRODUCER,
+        externalRecipient,
+        LocalDate.of(2026, 7, 12),
+      )
+    invoice.orderNetstone = order
+
+    val saved = invoiceNetstoneService.saveWithLines(invoice, emptyList())
+
+    assertThat(saved.recipientType).isEqualTo(InvoiceNetstone.RecipientType.PRODUCER)
+    assertThat(saved.recipient.id).isEqualTo(externalRecipient.id)
+  }
+
+  @Test
+  fun saveWithLines_throws_when_codig_company_missing() {
+    val (sale, order, _) = createSaleAndOrder("NOCOD")
+    val invoice = invoiceNetstoneService.prepareForSale(sale, order)
+    invoice.invoiceDate = LocalDate.of(2026, 7, 12)
+    // Remove the default Codig company so the lookup throws.
+    clientService.findDefaultCodigCompany().ifPresent { clientService.delete(it.id!!) }
+
+    assertThatThrownBy { invoiceNetstoneService.saveWithLines(invoice, emptyList()) }
+      .isInstanceOf(IllegalStateException::class.java)
+      .hasMessageContaining("société Codig")
+  }
+
+  @Test
   fun findByOrderNetstoneId_excludes_soft_deleted() {
     val (_, order, _) = createSaleAndOrder("SD1")
     val codig = clientService.findDefaultCodigCompany().orElseThrow()

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -12,6 +12,10 @@ import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.fiscalposition.FiscalPosition
 import fr.axl.lvy.fiscalposition.FiscalPositionRepository
+import fr.axl.lvy.invoice.InvoiceCodig
+import fr.axl.lvy.invoice.InvoiceCodigRepository
+import fr.axl.lvy.invoice.InvoiceNetstone
+import fr.axl.lvy.invoice.InvoiceNetstoneRepository
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigRepository
 import fr.axl.lvy.order.OrderCodigService
@@ -62,6 +66,8 @@ class PdfServiceTest {
   @Autowired lateinit var salesNetstoneRepository: SalesNetstoneRepository
   @Autowired lateinit var productRepository: ProductRepository
   @Autowired lateinit var productService: ProductService
+  @Autowired lateinit var invoiceCodigRepository: InvoiceCodigRepository
+  @Autowired lateinit var invoiceNetstoneRepository: InvoiceNetstoneRepository
   @Autowired lateinit var testData: TestDataFactory
 
   private val sampleLogoData =
@@ -1136,6 +1142,222 @@ class PdfServiceTest {
     assertThat(text).contains("PO-DIRECT-123")
     assertThat(text).contains("Direct Product")
     assertThat(text).contains("10,00 kg")
+  }
+
+  /** Codig invoice PDF: renders invoice number, client, lines, totals, and PO/incoterm details. */
+  @Test
+  fun generateInvoiceCodigPdf_renders_main_fields() {
+    val codigCompany =
+      clientService.findDefaultCodigCompany().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-INV-COD", "CoDIG SAS").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.CODIG
+          }
+        )
+      }
+    codigCompany.billingAddress = "12 rue de Paris\n75001 Paris\nFrance"
+    codigCompany.vatNumber = "FRINV001"
+    codigCompany.logoData = sampleLogoData
+    clientService.save(codigCompany)
+
+    val customer =
+      clientRepository.save(
+        Client("CLI-PDF-INV-CUS", "Invoice Customer").apply {
+          billingAddress = "9 Bill Lane\nLyon\nFrance"
+        }
+      )
+    val orderCodig =
+      orderCodigRepository.save(
+        OrderCodig("CA-PDF-INV-01", customer, LocalDate.of(2026, 4, 1)).apply {
+          incoterms = "CFR"
+          incotermLocation = "Le Havre"
+          currency = "USD"
+        }
+      )
+    salesCodigRepository.save(
+      SalesCodig("Cod-SO-INV-01", customer, LocalDate.of(2026, 4, 5)).apply {
+        this.orderCodig = orderCodig
+        clientReference = "PO-INV-CUSTOMER-001"
+        expectedDeliveryDate = LocalDate.of(2026, 5, 10)
+        incoterms = "CFR"
+        incotermLocation = "Le Havre"
+        currency = "USD"
+      }
+    )
+
+    val invoice =
+      invoiceCodigRepository.save(
+        InvoiceCodig("CoD_INV/2026/001", customer, LocalDate.of(2026, 5, 15)).apply {
+          this.orderCodig = orderCodig
+          clientName = customer.name
+          clientAddress = customer.billingAddress
+          status = InvoiceCodig.InvoiceCodigStatus.ISSUED
+          dueDate = LocalDate.of(2026, 6, 15)
+          incoterms = "CFR"
+          currency = "USD"
+        }
+      )
+    val product =
+      productRepository.save(
+        Product("PRD-PDF-INV", "CITRIC ACID").apply {
+          label = "Citric acid mono"
+          shortDescription = "Acidulant"
+          unit = "kg"
+          hsCode = "291814"
+          madeIn = "China"
+          sellingPriceExclTax = BigDecimal("2.50")
+        }
+      )
+    val invoiceLine =
+      DocumentLine(DocumentLine.DocumentType.INVOICE_CODIG, invoice.id!!, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("100.00")
+        unit = "kg"
+        unitPriceExclTax = BigDecimal("2.50")
+        vatRate = BigDecimal("20")
+        hsCode = product.hsCode
+        madeIn = product.madeIn
+        clientProductCode = "CUST-CITRIC-01"
+        recalculate()
+      }
+    documentLineRepository.save(invoiceLine)
+    invoice.recalculateTotals(listOf(invoiceLine))
+    invoiceCodigRepository.saveAndFlush(invoice)
+
+    val text = extractText(pdfService.generateInvoiceCodigPdf(invoice.id!!))
+
+    assertThat(text).contains("Invoice # CoD_INV/2026/001")
+    assertThat(text).contains("CoDIG SAS")
+    assertThat(text).contains("Invoice Customer")
+    assertThat(text).contains("PO-INV-CUSTOMER-001")
+    assertThat(text).contains("15/05/2026")
+    assertThat(text).contains("Citric acid mono")
+    assertThat(text).contains("100,00 kg")
+    assertThat(text).contains("$ 2,50")
+    assertThat(text).contains("$ 250,00")
+    assertThat(text).contains("$ 300,00")
+    assertThat(text).contains("CFR")
+    assertThat(text).contains("Made in China")
+    assertThat(text).contains("HS Code: 291814")
+    assertThat(text).contains("PC: CUST-CITRIC-01")
+  }
+
+  /** Netstone invoice PDF: renders invoice number, recipient (CoDIG), lines, totals. */
+  @Test
+  fun generateInvoiceNetstonePdf_renders_main_fields() {
+    val netstoneCompany =
+      clientService.findDefaultCodigSupplier().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-INV-NET", "Netstone").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.NETSTONE
+          }
+        )
+      }
+    netstoneCompany.billingAddress = "10/F., Guangdong Investment Tower\nHong Kong"
+    netstoneCompany.vatNumber = "HK-INV-001"
+    netstoneCompany.logoData = sampleLogoData
+    clientService.save(netstoneCompany)
+
+    val codigCompany =
+      clientService.findDefaultCodigCompany().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-INV-CO2", "CoDIG SAS").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.CODIG
+          }
+        )
+      }
+    codigCompany.billingAddress = "12 rue de Paris\n75001 Paris\nFrance"
+    clientService.save(codigCompany)
+
+    val customer = clientRepository.save(Client("CLI-PDF-INV-CUS2", "External Customer"))
+    val orderCodig =
+      orderCodigRepository.save(
+        OrderCodig("CA-PDF-INV-NET-01", customer, LocalDate.of(2026, 4, 1)).apply {
+          incoterms = "CFR"
+          incotermLocation = "Marseille"
+          currency = "USD"
+        }
+      )
+    val orderNetstone =
+      orderNetstoneService.saveWithLines(
+        OrderNetstone("NST-PO-INV-01", orderCodig).apply {
+          orderDate = LocalDate.of(2026, 4, 2)
+          incoterms = "CFR"
+          incotermLocation = "Marseille"
+        },
+        emptyList(),
+      )
+    val invoice =
+      invoiceNetstoneRepository.save(
+        InvoiceNetstone(
+            "NST_INV/2026/001",
+            InvoiceNetstone.RecipientType.COMPANY_CODIG,
+            codigCompany,
+            LocalDate.of(2026, 5, 18),
+          )
+          .apply {
+            this.orderNetstone = orderNetstone
+            origin = InvoiceNetstone.Origin.ORDER_LINKED
+            status = InvoiceNetstone.InvoiceNetstoneStatus.VERIFIED
+            dueDate = LocalDate.of(2026, 6, 18)
+            billingAddress = codigCompany.billingAddress
+          }
+      )
+    val product =
+      productRepository.save(
+        Product("PRD-PDF-INV-NET", "ASCORBIC ACID").apply {
+          label = "Vitamin C"
+          unit = "kg"
+          purchasePriceExclTax = BigDecimal("3.75")
+        }
+      )
+    val line =
+      DocumentLine(DocumentLine.DocumentType.INVOICE_NETSTONE, invoice.id!!, product.name).apply {
+        this.product = product
+        quantity = BigDecimal("80.00")
+        unit = "kg"
+        unitPriceExclTax = BigDecimal("3.75")
+        vatRate = BigDecimal.ZERO
+        recalculate()
+      }
+    documentLineRepository.save(line)
+    invoice.recalculateTotals(listOf(line))
+    invoiceNetstoneRepository.saveAndFlush(invoice)
+
+    val text = extractText(pdfService.generateInvoiceNetstonePdf(invoice.id!!))
+
+    assertThat(text).contains("Invoice # NST_INV/2026/001")
+    assertThat(text).contains("Netstone")
+    assertThat(text).contains("CoDIG SAS")
+    assertThat(text).contains("18/05/2026")
+    assertThat(text).contains("18/06/2026")
+    assertThat(text).contains("Vitamin C")
+    assertThat(text).contains("80,00 kg")
+    assertThat(text).contains("$ 3,75")
+    assertThat(text).contains("$ 300,00")
+    assertThat(text).contains("CA-PDF-INV-NET-01")
+  }
+
+  /** Unknown invoice id → IllegalArgumentException. */
+  @Test
+  fun generateInvoiceCodigPdf_throws_for_unknown_invoice() {
+    org.assertj.core.api.Assertions.assertThatThrownBy { pdfService.generateInvoiceCodigPdf(-1L) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  /** Unknown invoice id → IllegalArgumentException. */
+  @Test
+  fun generateInvoiceNetstonePdf_throws_for_unknown_invoice() {
+    org.assertj.core.api.Assertions.assertThatThrownBy {
+        pdfService.generateInvoiceNetstonePdf(-1L)
+      }
+      .isInstanceOf(IllegalArgumentException::class.java)
   }
 
   private fun extractText(bytes: ByteArray): String =

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -1344,6 +1344,119 @@ class PdfServiceTest {
     assertThat(text).contains("CA-PDF-INV-NET-01")
   }
 
+  /**
+   * Invoice without a linked sale → exercises the `sale == null` fallback paths in
+   * generateInvoiceCodigPdf (incoterm, incoterm location, payment term, customer reference, fiscal
+   * position remark all default to invoice fields or empty strings).
+   */
+  @Test
+  fun generateInvoiceCodigPdf_handles_invoice_without_sale() {
+    val customer =
+      clientRepository.save(
+        Client("CLI-PDF-INV-NOSALE", "Customer No Sale").apply {
+          billingAddress = "9 Bill Lane\nLyon\nFrance"
+        }
+      )
+    val orderCodig =
+      orderCodigRepository.save(OrderCodig("CA-PDF-NOSALE", customer, LocalDate.of(2026, 4, 1)))
+    val invoice =
+      invoiceCodigRepository.save(
+        InvoiceCodig("CoD_INV/2026/NS01", customer, LocalDate.of(2026, 5, 15)).apply {
+          this.orderCodig = orderCodig
+          incoterms = "FOB"
+          currency = "EUR"
+        }
+      )
+
+    val text = extractText(pdfService.generateInvoiceCodigPdf(invoice.id!!))
+
+    assertThat(text).contains("CoD_INV/2026/NS01")
+    assertThat(text).contains("FOB")
+  }
+
+  /**
+   * Invoice where the client has no billing address but the sale and invoice both carry one →
+   * exercises the deeper `?:` fallback in `clientAddressLines` and `invoicingAddressLines`.
+   */
+  @Test
+  fun generateInvoiceCodigPdf_falls_back_to_invoice_client_address() {
+    val customer = clientRepository.save(Client("CLI-PDF-INV-NOBILL", "No Billing Customer"))
+    val orderCodig =
+      orderCodigRepository.save(OrderCodig("CA-PDF-NOBILL", customer, LocalDate.of(2026, 4, 1)))
+    val invoice =
+      invoiceCodigRepository.save(
+        InvoiceCodig("CoD_INV/2026/NB01", customer, LocalDate.of(2026, 5, 15)).apply {
+          this.orderCodig = orderCodig
+          clientAddress = "Snapshot Address\n75001 Paris"
+          currency = "EUR"
+        }
+      )
+
+    val text = extractText(pdfService.generateInvoiceCodigPdf(invoice.id!!))
+
+    assertThat(text).contains("Snapshot Address")
+  }
+
+  /**
+   * Netstone invoice where the CoDIG own-company has no billing address → exercises the
+   * `clientAddressLines` and `invoicingAddressLines` fallback paths in generateInvoiceNetstonePdf.
+   */
+  @Test
+  fun generateInvoiceNetstonePdf_falls_back_when_codig_company_has_no_billing() {
+    val netstoneCompany =
+      clientService.findDefaultCodigSupplier().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-INV-NET2", "Netstone").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.NETSTONE
+          }
+        )
+      }
+    netstoneCompany.billingAddress = "10/F.\nHK"
+    clientService.save(netstoneCompany)
+    val codigCompany =
+      clientService.findDefaultCodigCompany().orElseGet {
+        clientService.save(
+          Client("CLI-PDF-INV-COD3", "CoDIG").apply {
+            type = Client.ClientType.OWN_COMPANY
+            role = Client.ClientRole.OWN_COMPANY
+            visibleCompany = User.Company.CODIG
+          }
+        )
+      }
+    codigCompany.billingAddress = null
+    clientService.save(codigCompany)
+
+    val customer = clientRepository.save(Client("CLI-PDF-NETC", "External"))
+    val orderCodig =
+      orderCodigRepository.save(OrderCodig("CA-PDF-NETC", customer, LocalDate.of(2026, 4, 1)))
+    val orderNetstone =
+      orderNetstoneService.saveWithLines(
+        OrderNetstone("NST-PO-NETC", orderCodig).apply { orderDate = LocalDate.of(2026, 4, 2) },
+        emptyList(),
+      )
+    val invoice =
+      invoiceNetstoneRepository.save(
+        InvoiceNetstone(
+            "NST_INV/2026/FB01",
+            InvoiceNetstone.RecipientType.COMPANY_CODIG,
+            codigCompany,
+            LocalDate.of(2026, 5, 18),
+          )
+          .apply {
+            this.orderNetstone = orderNetstone
+            origin = InvoiceNetstone.Origin.ORDER_LINKED
+            billingAddress = "Invoice Bill Snapshot\n75001 Paris"
+          }
+      )
+
+    val text = extractText(pdfService.generateInvoiceNetstonePdf(invoice.id!!))
+
+    assertThat(text).contains("NST_INV/2026/FB01")
+    assertThat(text).contains("Invoice Bill Snapshot")
+  }
+
   /** Unknown invoice id → IllegalArgumentException. */
   @Test
   fun generateInvoiceCodigPdf_throws_for_unknown_invoice() {

--- a/src/test/kotlin/fr/axl/lvy/sale/SalesNetstoneServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/sale/SalesNetstoneServiceTest.kt
@@ -39,6 +39,7 @@ class SalesNetstoneServiceTest {
   @Autowired lateinit var orderCodigRepository: OrderCodigRepository
   @Autowired lateinit var orderNetstoneService: OrderNetstoneService
   @Autowired lateinit var orderNetstoneRepository: OrderNetstoneRepository
+  @Autowired lateinit var paymentTermRepository: fr.axl.lvy.paymentterm.PaymentTermRepository
   @Autowired lateinit var testData: TestDataFactory
 
   @BeforeEach
@@ -547,6 +548,26 @@ class SalesNetstoneServiceTest {
     assertThat(saved.incotermLocation).isEqualTo("preset-location")
     assertThat(saved.fiscalPosition?.id).isEqualTo(fiscalPosition.id)
     assertThat(saved.currency).isEqualTo("GBP")
+  }
+
+  @Test
+  fun save_preserves_existing_payment_term() {
+    val client = testData.createClient("CLI-SB-PT-PRESET")
+    val salesCodig = createSalesCodigWithOrder("SA-SB-PT-PRESET", client)
+    // Order has a different term so we can prove the sale's preset survives.
+    val orderTerm =
+      paymentTermRepository.saveAndFlush(fr.axl.lvy.paymentterm.PaymentTerm("Order term"))
+    salesCodig.orderCodig!!.paymentTerm = orderTerm
+    salesCodigRepository.saveAndFlush(salesCodig)
+
+    val presetTerm =
+      paymentTermRepository.saveAndFlush(fr.axl.lvy.paymentterm.PaymentTerm("60 jours"))
+    val sale = SalesNetstone("SB-PT-PRESET-01", salesCodig)
+    sale.paymentTerm = presetTerm
+
+    val saved = salesNetstoneService.save(sale)
+
+    assertThat(saved.paymentTerm?.id).isEqualTo(presetTerm.id)
   }
 
   @Test


### PR DESCRIPTION
Description :
•
ajout du bouton Facture sur les ventes CoDIG et Netstone avec ouverture de la fenêtre facture liée
•
préremplissage des factures depuis la vente source, avec reprise des lignes et des prix de la vente
•
génération et prévisualisation des numéros de facture, avec attribution réelle uniquement à l’enregistrement
•
ajustements des formulaires CoDIG et Netstone : client, réf. client, conditions de paiement, incoterm, emplacement, adresse de facturation
•
simplification de la facture Netstone pour un client CoDIG
•
ajout du téléchargement PDF pour les factures CoDIG et Netstone
•
enrichissement du PDF de facture CoDIG avec client de la vente, références, incoterm, données logistiques et mentions complémentaires
•
ajout du statut facture Brouillon / Validée dans les fenêtres de facture