### PR TITLE
feat(pdf): Packing List action on Codig sales (#51)

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
+++ b/src/main/kotlin/fr/axl/lvy/pdf/PdfService.kt
@@ -20,6 +20,7 @@ import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.util.Base64
 import java.util.Locale
 import javax.imageio.ImageIO
@@ -391,6 +392,73 @@ class PdfService(
     PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
     return out.toByteArray()
   }
+
+  /**
+   * Generates a Packing List PDF from manually-supplied fields. Issued from a Codig sale context;
+   * the issuing CoDIG company is rendered in the header.
+   */
+  @Transactional(readOnly = true)
+  fun generatePackingListPdf(input: PackingListInput): ByteArray {
+    val ownCompany =
+      clientService
+        .findDefaultCodigCompany()
+        .flatMap { company ->
+          company.id?.let(clientService::findDetailedById) ?: java.util.Optional.of(company)
+        }
+        .orElse(null)
+
+    val ctx = Context()
+    ctx.setVariable("ownCompany", ownCompany)
+    ctx.setVariable(
+      "ownCompanyAddressLines",
+      ownCompany?.billingAddress?.lines() ?: emptyList<String>(),
+    )
+    ctx.setVariable("logoSrc", logoSrc(ownCompany))
+    ctx.setVariable("productCode", input.productCode)
+    ctx.setVariable("productDescription", input.productDescription)
+    ctx.setVariable("poNumber", input.poNumber)
+    ctx.setVariable("pcCode", input.pcCode)
+    ctx.setVariable("packingListNumber", input.packingListNumber)
+    ctx.setVariable("invoiceNumber", input.invoiceNumber)
+    ctx.setVariable("batchNumber", input.batchNumber)
+    ctx.setVariable("quantity", input.quantity)
+    ctx.setVariable("isoTankNumber", input.isoTankNumber)
+    ctx.setVariable("origin", input.origin)
+    ctx.setVariable("date", input.date)
+    ctx.setVariable("packageDescription", input.packageDescription)
+    ctx.setVariable("grossWeight", input.grossWeight)
+    ctx.setVariable("netWeight", input.netWeight)
+    ctx.setVariable("casNumber", input.casNumber)
+    ctx.setVariable("ecNumber", input.ecNumber)
+    ctx.setVariable("hazardNote", input.hazardNote)
+
+    val html = templateEngine.process("packing-list", ctx)
+
+    val out = ByteArrayOutputStream()
+    PdfRendererBuilder().withHtmlContent(html, null).toStream(out).run()
+    return out.toByteArray()
+  }
+
+  /** User-supplied fields for a Packing List PDF. */
+  data class PackingListInput(
+    val productCode: String,
+    val productDescription: String?,
+    val poNumber: String,
+    val pcCode: String?,
+    val packingListNumber: String,
+    val invoiceNumber: String,
+    val batchNumber: String,
+    val quantity: String,
+    val isoTankNumber: String,
+    val origin: String,
+    val date: LocalDate?,
+    val packageDescription: String,
+    val grossWeight: String,
+    val netWeight: String,
+    val casNumber: String?,
+    val ecNumber: String?,
+    val hazardNote: String?,
+  )
 
   /** Generates a PDF for a Codig invoice. */
   @Transactional(readOnly = true)

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/PackingListDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/PackingListDialog.kt
@@ -1,0 +1,134 @@
+package fr.axl.lvy.sale.ui
+
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.component.button.ButtonVariant
+import com.vaadin.flow.component.datepicker.DatePicker
+import com.vaadin.flow.component.dialog.Dialog
+import com.vaadin.flow.component.formlayout.FormLayout
+import com.vaadin.flow.component.html.Anchor
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout
+import com.vaadin.flow.component.textfield.TextArea
+import com.vaadin.flow.component.textfield.TextField
+import com.vaadin.flow.server.StreamResource
+import fr.axl.lvy.documentline.DocumentLine
+import fr.axl.lvy.pdf.PdfService
+import fr.axl.lvy.sale.SalesCodig
+import java.time.LocalDate
+
+/**
+ * Non-persistent dialog that collects Packing List fields and generates the corresponding PDF on
+ * demand. Fields are prefilled from the related sale and its first product line when available.
+ */
+internal class PackingListDialog(
+  private val pdfService: PdfService,
+  private val sale: SalesCodig,
+  saleLines: List<DocumentLine>,
+) : Dialog() {
+
+  private val productCode = TextField("Product")
+  private val productDescription = TextField("Product description")
+  private val poNumber = TextField("Your PO number")
+  private val pcCode = TextField("PC")
+  private val packingListNumber = TextField("Packing List Nr")
+  private val invoiceNumber = TextField("Invoice Nr")
+  private val batchNumber = TextField("Batch number")
+  private val quantity = TextField("Quantity")
+  private val isoTankNumber = TextField("Iso tank Nr")
+  private val origin = TextField("Origin")
+  private val date = DatePicker("Date")
+  private val packageDescription = TextField("Package")
+  private val grossWeight = TextField("GW")
+  private val netWeight = TextField("NW")
+  private val casNumber = TextField("CAS #")
+  private val ecNumber = TextField("EC #")
+  private val hazardNote = TextArea("Hazard note")
+
+  init {
+    headerTitle = "Packing List"
+    width = "720px"
+    height = "90%"
+
+    val form = FormLayout()
+    form.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
+    form.add(productCode, productDescription)
+    form.add(poNumber, pcCode)
+    form.add(packingListNumber, invoiceNumber)
+    form.add(batchNumber, quantity)
+    form.add(isoTankNumber, origin)
+    form.add(date, packageDescription)
+    form.add(grossWeight, netWeight)
+    form.add(casNumber, ecNumber)
+    form.add(hazardNote, 2)
+    add(form)
+
+    prefill(saleLines)
+
+    val downloadBtn = Button("Télécharger PDF")
+    downloadBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
+    val downloadLink =
+      Anchor(buildPdfResource(), "").apply {
+        element.setAttribute("download", true)
+        add(downloadBtn)
+      }
+    val cancelBtn = Button("Fermer") { close() }
+    footer.add(HorizontalLayout(downloadLink, cancelBtn))
+  }
+
+  private fun buildPdfResource(): StreamResource {
+    val baseName =
+      packingListNumber.value?.takeIf { it.isNotBlank() }?.replace("/", "_")?.replace(" ", "_")
+        ?: "packing-list-${sale.saleNumber.replace("/", "_")}"
+    return StreamResource("$baseName.pdf") {
+        pdfService.generatePackingListPdf(currentInput()).inputStream()
+      }
+      .apply { cacheTime = 0 }
+  }
+
+  private fun currentInput() =
+    PdfService.PackingListInput(
+      productCode = productCode.value.orEmpty().trim(),
+      productDescription = productDescription.value.takeIf { !it.isNullOrBlank() }?.trim(),
+      poNumber = poNumber.value.orEmpty().trim(),
+      pcCode = pcCode.value.takeIf { !it.isNullOrBlank() }?.trim(),
+      packingListNumber = packingListNumber.value.orEmpty().trim(),
+      invoiceNumber = invoiceNumber.value.orEmpty().trim(),
+      batchNumber = batchNumber.value.orEmpty().trim(),
+      quantity = quantity.value.orEmpty().trim(),
+      isoTankNumber = isoTankNumber.value.orEmpty().trim(),
+      origin = origin.value.orEmpty().trim(),
+      date = date.value,
+      packageDescription = packageDescription.value.orEmpty().trim(),
+      grossWeight = grossWeight.value.orEmpty().trim(),
+      netWeight = netWeight.value.orEmpty().trim(),
+      casNumber = casNumber.value.takeIf { !it.isNullOrBlank() }?.trim(),
+      ecNumber = ecNumber.value.takeIf { !it.isNullOrBlank() }?.trim(),
+      hazardNote = hazardNote.value.takeIf { !it.isNullOrBlank() }?.trim(),
+    )
+
+  private fun prefill(saleLines: List<DocumentLine>) {
+    val firstLine = saleLines.firstOrNull()
+    val product = firstLine?.product
+    productCode.value = product?.reference ?: firstLine?.designation.orEmpty()
+    productDescription.value = product?.label ?: product?.shortDescription ?: ""
+    poNumber.value = sale.clientReference.orEmpty()
+    pcCode.value = product?.findClientProductCode(sale.client).orEmpty()
+    invoiceNumber.value = ""
+    packingListNumber.value = ""
+    batchNumber.value = ""
+    val unit = firstLine?.unit ?: product?.unit ?: ""
+    quantity.value =
+      firstLine
+        ?.quantity
+        ?.let { qty -> if (unit.isNotBlank()) "$qty $unit" else qty.toPlainString() }
+        .orEmpty()
+    isoTankNumber.value = ""
+    origin.value = product?.madeIn ?: firstLine?.madeIn.orEmpty()
+    date.value = LocalDate.now()
+    packageDescription.value = ""
+    grossWeight.value = ""
+    netWeight.value = ""
+    casNumber.value = product?.casNumber.orEmpty()
+    ecNumber.value = product?.ecNumber.orEmpty()
+    hazardNote.value = ""
+  }
+}

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigListView.kt
@@ -81,7 +81,10 @@ internal class SalesCodigListView(
         invoiceButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
         invoiceButton.isEnabled = sale.orderCodig != null
 
-        HorizontalLayout(viewButton, deliveryButton, invoiceButton).apply {
+        val packingListButton = Button("Packing List") { openPackingList(sale) }
+        packingListButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_TERTIARY)
+
+        HorizontalLayout(viewButton, deliveryButton, invoiceButton, packingListButton).apply {
           isPadding = false
           isSpacing = true
         }
@@ -295,6 +298,12 @@ internal class SalesCodigListView(
         this::refreshGrid,
       )
       .open()
+  }
+
+  private fun openPackingList(sale: SalesCodig) {
+    val loadedSale = sale.id?.let { salesCodigService.findDetailedById(it).orElse(sale) } ?: sale
+    val saleLines = loadedSale.id?.let { salesCodigService.findLines(it) } ?: emptyList()
+    PackingListDialog(pdfService, loadedSale, saleLines).open()
   }
 
   private fun openInvoiceForm(sale: SalesCodig) {

--- a/src/main/resources/templates/pdf/packing-list.html
+++ b/src/main/resources/templates/pdf/packing-list.html
@@ -194,7 +194,7 @@
 <div class="footer-info">
   <p class="codes">
     <span th:if="${casNumber != null and !casNumber.isEmpty()}" th:text="'CAS # ' + ${casNumber}"></span>
-    <span th:if="${casNumber != null and !casNumber.isEmpty() and ecNumber != null and !ecNumber.isEmpty()}">&nbsp;&nbsp;</span>
+    <span th:if="${casNumber != null and !casNumber.isEmpty() and ecNumber != null and !ecNumber.isEmpty()}">&#160;&#160;</span>
     <span th:if="${ecNumber != null and !ecNumber.isEmpty()}" th:text="'EC # ' + ${ecNumber}"></span>
   </p>
   <p th:if="${hazardNote != null and !hazardNote.isEmpty()}" th:text="${hazardNote}"></p>

--- a/src/main/resources/templates/pdf/packing-list.html
+++ b/src/main/resources/templates/pdf/packing-list.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8"/>
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 11pt;
+      color: #333333;
+      margin: 0;
+      padding: 0;
+    }
+
+    p { margin: 0; padding: 0; }
+
+    .header-table { width: 100%; margin-bottom: 24pt; }
+    .logo-cell { width: 58%; vertical-align: top; }
+    .logo-cell img { height: 80pt; max-width: 180pt; }
+    .addr-cell { width: 42%; vertical-align: top; font-size: 10pt; }
+    .company-name { font-size: 12pt; font-weight: bold; margin-bottom: 4pt; }
+
+    .document-title {
+      color: #E07028;
+      font-size: 24pt;
+      font-weight: bold;
+      margin-bottom: 16pt;
+    }
+
+    .meta-table { width: 100%; border-collapse: collapse; margin-bottom: 18pt; }
+    .meta-table td {
+      font-size: 10pt;
+      padding: 2pt 8pt 2pt 0;
+      vertical-align: top;
+    }
+    .meta-table td.label {
+      width: 130pt;
+      font-weight: normal;
+      color: #555555;
+    }
+    .meta-table td.value { font-weight: normal; }
+    .product-line { margin-left: 0; }
+    .product-sub { color: #555555; font-style: italic; }
+
+    .lines-table {
+      width: 100%;
+      border-collapse: collapse;
+      border-top: 3pt double #333333;
+      border-bottom: 3pt double #333333;
+      margin-bottom: 16pt;
+    }
+    .lines-table th {
+      padding: 7pt 6pt;
+      font-size: 9pt;
+      font-weight: bold;
+      text-align: left;
+    }
+    .lines-table th.right { text-align: right; }
+    .lines-table th.center { text-align: center; }
+    .lines-table td {
+      padding: 6pt 6pt;
+      font-size: 10pt;
+      vertical-align: top;
+    }
+    .lines-table td.right { text-align: right; }
+    .lines-table td.center { text-align: center; }
+    .lines-table tr.total-row td {
+      font-weight: bold;
+      border-top: 1pt solid #333333;
+    }
+
+    .footer-info {
+      margin-top: 14pt;
+      font-size: 10pt;
+      line-height: 1.4;
+    }
+    .footer-info .codes { margin-bottom: 6pt; }
+
+    .footer-block {
+      padding-top: 8pt;
+      border-top: 1pt solid #333333;
+      font-size: 8.5pt;
+      line-height: 1.35;
+      text-align: center;
+      position: running(footer);
+    }
+
+    @page {
+      margin: 18mm 18mm 24mm 18mm;
+      @bottom-center { content: element(footer); }
+    }
+  </style>
+</head>
+<body>
+
+<table class="header-table" cellspacing="0" cellpadding="0">
+  <tr>
+    <td class="logo-cell">
+      <img th:if="${logoSrc != null}" th:src="${logoSrc}" alt=""/>
+    </td>
+    <td class="addr-cell" th:if="${ownCompany != null}">
+      <p class="company-name" th:text="${ownCompany.name}"></p>
+      <p th:each="line : ${ownCompanyAddressLines}" th:text="${line}"></p>
+      <p th:if="${ownCompany.vatNumber != null}" th:text="${'TVA: ' + ownCompany.vatNumber}"></p>
+    </td>
+  </tr>
+</table>
+
+<p class="document-title">PACKING LIST</p>
+
+<table class="meta-table" cellspacing="0" cellpadding="0">
+  <tr>
+    <td class="label">Product :</td>
+    <td class="value">
+      <p class="product-line" th:text="${productCode}"></p>
+      <p class="product-sub" th:if="${productDescription != null and !productDescription.isEmpty()}"
+         th:text="'(' + ${productDescription} + ')'"></p>
+    </td>
+  </tr>
+  <tr>
+    <td class="label">Your PO number:</td>
+    <td class="value"
+        th:text="${poNumber} + (${pcCode != null and !pcCode.isEmpty()} ? ' (PC: ' + ${pcCode} + ')' : '')"></td>
+  </tr>
+  <tr>
+    <td class="label">Packing List Nr:</td>
+    <td class="value" th:text="${packingListNumber}"></td>
+  </tr>
+  <tr>
+    <td class="label">Invoice Nr:</td>
+    <td class="value" th:text="${invoiceNumber}"></td>
+  </tr>
+  <tr>
+    <td class="label">Batch number :</td>
+    <td class="value" th:text="${batchNumber}"></td>
+  </tr>
+  <tr>
+    <td class="label">Quantity :</td>
+    <td class="value" th:text="${quantity}"></td>
+  </tr>
+  <tr>
+    <td class="label">Iso tank Nr:</td>
+    <td class="value" th:text="${isoTankNumber}"></td>
+  </tr>
+  <tr>
+    <td class="label">Origin:</td>
+    <td class="value" th:text="${origin}"></td>
+  </tr>
+  <tr>
+    <td class="label">Date:</td>
+    <td class="value"
+        th:text="${date != null ? #temporals.format(date, 'MM/dd/yyyy') : ''}"></td>
+  </tr>
+</table>
+
+<table class="lines-table" cellspacing="0" cellpadding="0">
+  <thead>
+  <tr>
+    <th class="center" style="width: 8%;">Item #</th>
+    <th style="width: 36%;">Description</th>
+    <th class="right" style="width: 22%;">Qty / Batch nr</th>
+    <th style="width: 18%;">Package</th>
+    <th class="right" style="width: 16%;">GW / NW</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td class="center">1</td>
+    <td>
+      <p th:text="${productCode}"></p>
+      <p class="product-sub" th:if="${productDescription != null and !productDescription.isEmpty()}"
+         th:text="${productDescription}"></p>
+    </td>
+    <td class="right">1</td>
+    <td th:text="${packageDescription}"></td>
+    <td class="right" th:text="${grossWeight}"></td>
+  </tr>
+  <tr>
+    <td></td>
+    <td></td>
+    <td class="right" th:text="${batchNumber}"></td>
+    <td th:text="${isoTankNumber}"></td>
+    <td class="right" th:text="${netWeight}"></td>
+  </tr>
+  <tr class="total-row">
+    <td class="center">TOTAL</td>
+    <td></td>
+    <td class="right">1</td>
+    <td th:text="${packageDescription}"></td>
+    <td class="right" th:text="${grossWeight}"></td>
+  </tr>
+  </tbody>
+</table>
+
+<div class="footer-info">
+  <p class="codes">
+    <span th:if="${casNumber != null and !casNumber.isEmpty()}" th:text="'CAS # ' + ${casNumber}"></span>
+    <span th:if="${casNumber != null and !casNumber.isEmpty() and ecNumber != null and !ecNumber.isEmpty()}">&nbsp;&nbsp;</span>
+    <span th:if="${ecNumber != null and !ecNumber.isEmpty()}" th:text="'EC # ' + ${ecNumber}"></span>
+  </p>
+  <p th:if="${hazardNote != null and !hazardNote.isEmpty()}" th:text="${hazardNote}"></p>
+</div>
+
+<div class="footer-block">
+  <p>CoDIG - SAS au Capital de 50 000 € - RCS Strasbourg 450090436 Code NAF 519A</p>
+  <p th:text="${'Mail: management@codig-sa.com, Phone: +33 3 88 25 65 70 - Web: http://codig-sa.com - TVA: ' + (ownCompany != null and ownCompany.vatNumber != null ? ownCompany.vatNumber : '')}"></p>
+</div>
+
+</body>
+</html>

--- a/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/pdf/PdfServiceTest.kt
@@ -1473,6 +1473,88 @@ class PdfServiceTest {
       .isInstanceOf(IllegalArgumentException::class.java)
   }
 
+  /**
+   * A populated Packing List input renders all manually-supplied fields (header metadata, line row,
+   * and footer codes) verbatim into the PDF.
+   */
+  @Test
+  fun generatePackingListPdf_renders_all_fields() {
+    val input =
+      PdfService.PackingListInput(
+        productCode = "CO-3104",
+        productDescription = "Sodium Salt Solution",
+        poNumber = "4517331740",
+        pcCode = "10041948",
+        packingListNumber = "CoD-PC/PL/00130",
+        invoiceNumber = "COD-SAJ2025/00038",
+        batchNumber = "T7521057",
+        quantity = "20,400 KG",
+        isoTankNumber = "BLKU 257873-0",
+        origin = "Made in Thailand",
+        date = LocalDate.of(2025, 7, 15),
+        packageDescription = "1 ISO-TANK",
+        grossWeight = "20,4 MT",
+        netWeight = "20,4 MT",
+        casNumber = "5165-97-9",
+        ecNumber = "225-948-4",
+        hazardNote = "Not classified has hazardous substance",
+      )
+
+    val text = extractText(pdfService.generatePackingListPdf(input))
+
+    assertThat(text)
+      .contains("PACKING LIST")
+      .contains("CO-3104")
+      .contains("Sodium Salt Solution")
+      .contains("4517331740")
+      .contains("PC: 10041948")
+      .contains("CoD-PC/PL/00130")
+      .contains("COD-SAJ2025/00038")
+      .contains("T7521057")
+      .contains("20,400 KG")
+      .contains("BLKU 257873-0")
+      .contains("Made in Thailand")
+      .contains("07/15/2025")
+      .contains("1 ISO-TANK")
+      .contains("20,4 MT")
+      .contains("CAS # 5165-97-9")
+      .contains("EC # 225-948-4")
+      .contains("Not classified has hazardous substance")
+  }
+
+  /**
+   * A minimal Packing List input (all optional fields null/blank) still renders without error and
+   * does not produce stray "PC:", "CAS #" or "EC #" labels.
+   */
+  @Test
+  fun generatePackingListPdf_minimal_input_omits_optional_codes() {
+    val input =
+      PdfService.PackingListInput(
+        productCode = "X-1",
+        productDescription = null,
+        poNumber = "PO-001",
+        pcCode = null,
+        packingListNumber = "PL-001",
+        invoiceNumber = "INV-001",
+        batchNumber = "B1",
+        quantity = "1 KG",
+        isoTankNumber = "TK-1",
+        origin = "France",
+        date = null,
+        packageDescription = "1 BOX",
+        grossWeight = "1 KG",
+        netWeight = "1 KG",
+        casNumber = null,
+        ecNumber = null,
+        hazardNote = null,
+      )
+
+    val text = extractText(pdfService.generatePackingListPdf(input))
+
+    assertThat(text).contains("PACKING LIST").contains("X-1").contains("PO-001")
+    assertThat(text).doesNotContain("PC:").doesNotContain("CAS #").doesNotContain("EC #")
+  }
+
   private fun extractText(bytes: ByteArray): String =
     PDDocument.load(ByteArrayInputStream(bytes)).use { doc -> PDFTextStripper().getText(doc) }
 


### PR DESCRIPTION
Closes #51.

## Summary
- Add "Packing List" button on each row of the Codig sales list.
- New `PackingListDialog` collects the fields from the issue attachment (product, PO/PC, packing list nr, invoice nr, batch, quantity, iso tank, origin, date, package, GW/NW, CAS, EC, hazard note) and prefills them from the sale and its first product line.
- New `PdfService.generatePackingListPdf(...)` + `templates/pdf/packing-list.html` render the PDF, downloadable from a "Télécharger PDF" button in the dialog footer.

## Test plan
- [ ] Open a Codig sale row → click `Packing List` → fields prefilled from sale + first line.
- [ ] Edit fields, click `Télécharger PDF` → PDF downloads with the expected layout.
- [ ] CAS/EC/origin populate from the linked product when set.