### PR TITLE
feat: Refonte des prix produit par société et par client

### DIFF
--- a/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteCodigFormDialog.kt
@@ -12,12 +12,14 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.delivery.DeliveryNoteCodig
 import fr.axl.lvy.delivery.DeliveryNoteCodigService
 import fr.axl.lvy.delivery.DeliveryNoteNetstone
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.pdf.PdfService
+import java.io.ByteArrayInputStream
 
 internal class DeliveryNoteCodigFormDialog(
   private val deliveryNoteCodigService: DeliveryNoteCodigService,
@@ -69,17 +71,14 @@ internal class DeliveryNoteCodigFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (note?.id != null) {
-      val pdfResource =
-        StreamResource("${note.deliveryNoteNumber.replace("/", "_")}.pdf") {
-            pdfService.generateDeliveryCodigPdf(note.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${note.deliveryNoteNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateDeliveryCodigPdf(note.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteCodigFormDialog.kt
@@ -75,7 +75,12 @@ internal class DeliveryNoteCodigFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateDeliveryCodigPdf(note.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteNetstoneFormDialog.kt
@@ -12,7 +12,8 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.noGap
 import fr.axl.lvy.delivery.DeliveryNoteNetstone
 import fr.axl.lvy.delivery.DeliveryNoteNetstoneService
@@ -21,6 +22,7 @@ import fr.axl.lvy.documentline.ui.DocumentLineEditor
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
+import java.io.ByteArrayInputStream
 
 internal class DeliveryNoteNetstoneFormDialog(
   private val deliveryNoteNetstoneService: DeliveryNoteNetstoneService,
@@ -85,17 +87,14 @@ internal class DeliveryNoteNetstoneFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (note?.id != null) {
-      val pdfResource =
-        StreamResource("${note.deliveryNoteNumber.replace("/", "_")}.pdf") {
-            pdfService.generateDeliveryNetstonePdf(note.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${note.deliveryNoteNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateDeliveryNetstonePdf(note.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/delivery/ui/DeliveryNoteNetstoneFormDialog.kt
@@ -91,7 +91,12 @@ internal class DeliveryNoteNetstoneFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateDeliveryNetstonePdf(note.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/documentline/DocumentLine.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/DocumentLine.kt
@@ -119,10 +119,7 @@ class DocumentLine(
       return Totals(exclTax, vat, exclTax.add(vat))
     }
 
-    /**
-     * Creates a new line pre-filled with the product's selling price, HS code, origin, and
-     * client-specific code.
-     */
+    /** Creates a new line pre-filled with the product metadata used on business documents. */
     fun fromProduct(
       documentType: DocumentType,
       documentId: Long,
@@ -136,9 +133,8 @@ class DocumentLine(
       line.madeIn = product.madeIn
       line.clientProductCode = product.findClientProductCode(client)
       line.unit = product.unit
-      line.unitPriceExclTax =
-        if (usePurchasePrice) product.purchasePriceExclTax else product.sellingPriceExclTax
       line.quantity = BigDecimal.ONE
+      line.unitPriceExclTax = BigDecimal.ZERO
       line.discountPercent = BigDecimal.ZERO
       line.vatRate = BigDecimal.ZERO
       line.recalculate()

--- a/src/main/kotlin/fr/axl/lvy/documentline/ui/DocumentLineEditor.kt
+++ b/src/main/kotlin/fr/axl/lvy/documentline/ui/DocumentLineEditor.kt
@@ -209,13 +209,16 @@ class DocumentLineEditor(
         clientSupplier?.invoke(),
         usePurchasePrice,
       )
-    // Update document-level currency to match the product's currency. When lines use mixed
-    // currencies, the last-added product's currency wins — this is intentional as CoDIG documents
-    // are single-currency.
-    currencyUpdater?.invoke(
-      if (usePurchasePrice) product.purchaseCurrency else product.sellingCurrency
-    )
-    unitPriceOverrideProvider?.invoke(product)?.let { line.unitPriceExclTax = it }
+    val client = clientSupplier?.invoke()
+    val resolvedUnitPrice =
+      unitPriceOverrideProvider?.invoke(product)
+        ?: productService.resolveUnitPrice(documentType, product, client, usePurchasePrice)
+    val resolvedCurrency =
+      productService.resolveCurrency(documentType, product, client, usePurchasePrice)
+    resolvedUnitPrice?.let { line.unitPriceExclTax = it }
+    if (resolvedCurrency != null) {
+      currencyUpdater?.invoke(resolvedCurrency)
+    }
     if (lineTaxMode == LineTaxMode.VAT) {
       line.vatRate = defaultVatRate
     }

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
@@ -13,7 +13,8 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.noGap
 import fr.axl.lvy.delivery.DeliveryNoteNetstone
 import fr.axl.lvy.documentline.DocumentLine
@@ -24,6 +25,7 @@ import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodig
+import java.io.ByteArrayInputStream
 
 /**
  * Dialog used to create or edit a [InvoiceCodig] from a [SalesCodig]. The form is read-only for the
@@ -123,17 +125,14 @@ internal class InvoiceCodigFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (invoice.id != null) {
-      val pdfResource =
-        StreamResource("${invoice.invoiceNumber.replace("/", "_")}.pdf") {
-            pdfService.generateInvoiceCodigPdf(invoice.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${invoice.invoiceNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateInvoiceCodigPdf(invoice.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceCodigFormDialog.kt
@@ -129,7 +129,12 @@ internal class InvoiceCodigFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateInvoiceCodigPdf(invoice.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
@@ -120,7 +120,12 @@ internal class InvoiceNetstoneFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateInvoiceNetstonePdf(invoice.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/invoice/ui/InvoiceNetstoneFormDialog.kt
@@ -13,7 +13,8 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.noGap
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.ui.DocumentLineEditor
@@ -23,6 +24,7 @@ import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesNetstone
+import java.io.ByteArrayInputStream
 
 /**
  * Dialog used to create or edit an [InvoiceNetstone] from a [SalesNetstone]. The recipient is
@@ -114,17 +116,14 @@ internal class InvoiceNetstoneFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (invoice.id != null) {
-      val pdfResource =
-        StreamResource("${invoice.internalInvoiceNumber.replace("/", "_")}.pdf") {
-            pdfService.generateInvoiceNetstonePdf(invoice.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${invoice.internalInvoiceNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateInvoiceNetstonePdf(invoice.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
@@ -5,6 +5,8 @@ import fr.axl.lvy.client.ClientService
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.documentline.DocumentLineService
+import fr.axl.lvy.product.ProductPriceCompany
+import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodigRepository
 import fr.axl.lvy.sale.SalesNetstoneService
 import io.micrometer.core.instrument.MeterRegistry
@@ -33,6 +35,7 @@ class OrderCodigService(
   private val salesNetstoneService: SalesNetstoneService,
   private val numberSequenceService: NumberSequenceService,
   private val clientService: ClientService,
+  private val productService: ProductService,
   private val meterRegistry: MeterRegistry,
 ) {
   // Pre-registered so they appear in Prometheus at startup with value 0.
@@ -238,7 +241,11 @@ class OrderCodigService(
     for (line in mtoLines) {
       val newLine =
         DocumentLine(DocumentLine.DocumentType.ORDER_NETSTONE, orderNetstone.id!!, line.designation)
-      newLine.copyFieldsFrom(line, overrideUnitPrice = line.product!!.purchasePriceExclTax)
+      newLine.copyFieldsFrom(
+        line,
+        overrideUnitPrice =
+          productService.findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)?.priceExclTax,
+      )
       newLine.position = line.position
       documentLineRepository.save(newLine)
     }
@@ -290,7 +297,7 @@ class OrderCodigService(
     saved.recalculateTotals(persistedLines)
     saved.purchasePriceExclTax =
       persistedLines.fold(BigDecimal.ZERO) { acc, line ->
-        acc.add((line.product?.purchasePriceExclTax ?: BigDecimal.ZERO).multiply(line.quantity))
+        acc.add(line.unitPriceExclTax.multiply(line.quantity))
       }
     val persistedOrder = orderCodigRepository.save(saved)
     val orderId = persistedOrder.id ?: return persistedOrder

--- a/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/OrderCodigService.kt
@@ -244,7 +244,9 @@ class OrderCodigService(
       newLine.copyFieldsFrom(
         line,
         overrideUnitPrice =
-          productService.findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)?.priceExclTax,
+          productService
+            .findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)
+            ?.priceExclTax,
       )
       newLine.position = line.position
       documentLineRepository.save(newLine)

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigFormDialog.kt
@@ -14,7 +14,8 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.BigDecimalField
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.DocumentFlowNavigation
 import fr.axl.lvy.base.ui.DocumentFlowNavigator
 import fr.axl.lvy.base.ui.DocumentFlowStep
@@ -33,6 +34,7 @@ import fr.axl.lvy.paymentterm.PaymentTerm
 import fr.axl.lvy.paymentterm.PaymentTermService
 import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
+import java.io.ByteArrayInputStream
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -139,17 +141,14 @@ internal class CommandCodigFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (order?.id != null) {
-      val pdfResource =
-        StreamResource("${order.orderNumber.replace("/", "_")}.pdf") {
-            pdfService.generateOrderCodigPdf(order.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${order.orderNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateOrderCodigPdf(order.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandCodigFormDialog.kt
@@ -145,7 +145,12 @@ internal class CommandCodigFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateOrderCodigPdf(order.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
@@ -291,15 +296,12 @@ internal class CommandCodigFormDialog(
               onOpenLinkedSale.invoke(currentOrder)
             }
           else null,
-        openSalesNetstone =
-          if (hasLinkedNetstoneSale && onOpenLinkedNetstoneSale != null)
-            Runnable {
-              close()
-              onOpenLinkedNetstoneSale.invoke(currentOrder)
-            }
-          else null,
+        openSalesNetstone = {
+          close()
+          onOpenLinkedNetstoneSale.invoke(currentOrder)
+        },
         openOrderNetstone =
-          if (hasLinkedNetstoneSale && onOpenLinkedNetstoneOrder != null)
+          if (onOpenLinkedNetstoneOrder != null)
             Runnable {
               close()
               onOpenLinkedNetstoneOrder.invoke(currentOrder)

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
@@ -14,7 +14,8 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
 import com.vaadin.flow.data.provider.DataProvider
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.DocumentFlowNavigation
 import fr.axl.lvy.base.ui.DocumentFlowNavigator
 import fr.axl.lvy.base.ui.DocumentFlowStep
@@ -38,6 +39,7 @@ import fr.axl.lvy.pdf.PdfService
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesNetstone
 import fr.axl.lvy.sale.SalesNetstoneService
+import java.io.ByteArrayInputStream
 import java.math.BigDecimal
 
 internal class CommandNetstoneFormDialog(
@@ -72,7 +74,6 @@ internal class CommandNetstoneFormDialog(
   private val notes = TextArea("Notes")
   private val lineEditor: DocumentLineEditor
   private val allIncoterms: List<Incoterm>
-  private var selectedCurrency: String = "EUR"
   private val visibleStatuses =
     listOf(
       OrderNetstone.OrderNetstoneStatus.SENT,
@@ -124,8 +125,6 @@ internal class CommandNetstoneFormDialog(
         productService = productService,
         documentType = DocumentLine.DocumentType.ORDER_NETSTONE,
         clientSupplier = { orderCodigCombo.value?.client },
-        currencySupplier = { selectedCurrency },
-        currencyUpdater = { selectedCurrency = it },
         lineTaxMode = DocumentLineEditor.LineTaxMode.VAT,
         defaultVatRate = BigDecimal.ZERO,
       )
@@ -141,17 +140,14 @@ internal class CommandNetstoneFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (order?.id != null) {
-      val pdfResource =
-        StreamResource("${order.orderNumber}.pdf") {
-            pdfService.generateOrderNetstonePdf(order.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${order.orderNumber}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateOrderNetstonePdf(order.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/order/ui/CommandNetstoneFormDialog.kt
@@ -144,7 +144,12 @@ internal class CommandNetstoneFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateOrderNetstonePdf(order.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/product/Product.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/Product.kt
@@ -13,10 +13,9 @@ import org.hibernate.type.SqlTypes
  * [ProductType.SERVICE]. Physical products may be flagged as [mto] (made-to-order), meaning they
  * trigger a supplier purchase order when sold.
  *
- * Pricing is stored outside the product sheet:
- * [purchasePrices] for CoDIG/Netstone purchase costs and [sellingPrices] for CoDIG client-specific
- * selling prices. The product itself keeps only stable catalog data plus per-client reference codes
- * via [clientProductCodes].
+ * Pricing is stored outside the product sheet: [purchasePrices] for CoDIG/Netstone purchase costs
+ * and [sellingPrices] for CoDIG client-specific selling prices. The product itself keeps only
+ * stable catalog data plus per-client reference codes via [clientProductCodes].
  */
 @Entity
 @Table(name = "products")
@@ -170,7 +169,9 @@ class Product(
     validEntries.forEach { entry ->
       val clientId = entry.client.id ?: return@forEach
       if (clientId !in existingClientIds) {
-        sellingPrices.add(ProductSellingPrice(this, entry.client, entry.priceExclTax, entry.currency))
+        sellingPrices.add(
+          ProductSellingPrice(this, entry.client, entry.priceExclTax, entry.currency)
+        )
       }
     }
   }

--- a/src/main/kotlin/fr/axl/lvy/product/Product.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/Product.kt
@@ -13,8 +13,10 @@ import org.hibernate.type.SqlTypes
  * [ProductType.SERVICE]. Physical products may be flagged as [mto] (made-to-order), meaning they
  * trigger a supplier purchase order when sold.
  *
- * Each product tracks both a selling price and a purchase price (possibly in different currencies),
- * and can have per-client custom reference codes via [clientProductCodes].
+ * Pricing is stored outside the product sheet:
+ * [purchasePrices] for CoDIG/Netstone purchase costs and [sellingPrices] for CoDIG client-specific
+ * selling prices. The product itself keeps only stable catalog data plus per-client reference codes
+ * via [clientProductCodes].
  */
 @Entity
 @Table(name = "products")
@@ -38,10 +40,6 @@ class Product(
   @JdbcTypeCode(SqlTypes.VARCHAR)
   @Column(nullable = false, columnDefinition = "enum('PRODUCT','SERVICE')")
   var type: ProductType = ProductType.PRODUCT
-
-  /** Free-text field for purchase price conditions (e.g. "Prix départ usine"). */
-  @Column(name = "price_type", length = 100, columnDefinition = "varchar(100)")
-  var priceType: String? = null
 
   @Column(name = "is_mto", nullable = false) var mto: Boolean = false
 
@@ -73,6 +71,12 @@ class Product(
 
   @OneToMany(mappedBy = "product", cascade = [CascadeType.ALL], orphanRemoval = true)
   var clientProductCodes: MutableList<ProductClientCode> = mutableListOf()
+
+  @OneToMany(mappedBy = "product", cascade = [CascadeType.ALL], orphanRemoval = true)
+  var purchasePrices: MutableList<ProductPurchasePrice> = mutableListOf()
+
+  @OneToMany(mappedBy = "product", cascade = [CascadeType.ALL], orphanRemoval = true)
+  var sellingPrices: MutableList<ProductSellingPrice> = mutableListOf()
 
   @ManyToMany
   @JoinTable(
@@ -120,6 +124,57 @@ class Product(
       clientProductCodes.firstOrNull { it.client == currentClient }?.code
     }
 
+  /** Replaces the internal-company purchase prices kept on the product. */
+  fun replacePurchasePrices(entries: List<PurchasePriceEntry>) {
+    val byCompany = entries.associateBy { it.company }
+
+    val iterator = purchasePrices.iterator()
+    while (iterator.hasNext()) {
+      val current = iterator.next()
+      val desired = byCompany[current.company]
+      if (desired == null) {
+        iterator.remove()
+      } else {
+        current.priceExclTax = desired.priceExclTax
+        current.currency = desired.currency
+      }
+    }
+
+    val existingCompanies = purchasePrices.map { it.company }.toSet()
+    byCompany.forEach { (company, entry) ->
+      if (company !in existingCompanies) {
+        purchasePrices.add(ProductPurchasePrice(this, company, entry.priceExclTax, entry.currency))
+      }
+    }
+  }
+
+  /** Replaces the client-specific selling prices kept on the product. */
+  fun replaceSellingPrices(entries: List<SellingPriceEntry>) {
+    val validEntries = entries.filter { it.client.id != null }
+    val entriesByClientId = validEntries.associateBy { it.client.id!! }
+
+    val iterator = sellingPrices.iterator()
+    while (iterator.hasNext()) {
+      val current = iterator.next()
+      val desired = current.client.id?.let(entriesByClientId::get)
+      if (desired == null) {
+        iterator.remove()
+      } else {
+        current.client = desired.client
+        current.priceExclTax = desired.priceExclTax
+        current.currency = desired.currency
+      }
+    }
+
+    val existingClientIds = sellingPrices.mapNotNull { it.client.id }.toSet()
+    validEntries.forEach { entry ->
+      val clientId = entry.client.id ?: return@forEach
+      if (clientId !in existingClientIds) {
+        sellingPrices.add(ProductSellingPrice(this, entry.client, entry.priceExclTax, entry.currency))
+      }
+    }
+  }
+
   fun replaceSuppliers(clients: Collection<Client>) {
     suppliers.clear()
     suppliers.addAll(clients)
@@ -142,4 +197,16 @@ class Product(
     PRODUCT,
     SERVICE,
   }
+
+  data class PurchasePriceEntry(
+    val company: ProductPriceCompany,
+    val priceExclTax: BigDecimal,
+    val currency: String,
+  )
+
+  data class SellingPriceEntry(
+    val client: Client,
+    val priceExclTax: BigDecimal,
+    val currency: String,
+  )
 }

--- a/src/main/kotlin/fr/axl/lvy/product/ProductPriceCompany.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductPriceCompany.kt
@@ -1,0 +1,7 @@
+package fr.axl.lvy.product
+
+/** Internal company for which a product purchase price applies. */
+enum class ProductPriceCompany {
+  CODIG,
+  NETSTONE,
+}

--- a/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePrice.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePrice.kt
@@ -1,0 +1,30 @@
+package fr.axl.lvy.product
+
+import fr.axl.lvy.base.BaseEntity
+import jakarta.persistence.*
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+
+/** Purchase price of a product for one internal company. */
+@Entity
+@Table(
+  name = "product_purchase_prices",
+  uniqueConstraints =
+    [UniqueConstraint(name = "uk_product_purchase_price_company", columnNames = ["product_id", "company"])],
+)
+class ProductPurchasePrice(
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "product_id", nullable = false)
+  var product: Product,
+  @Enumerated(EnumType.STRING)
+  @JdbcTypeCode(SqlTypes.VARCHAR)
+  @Column(nullable = false, columnDefinition = "enum('CODIG','NETSTONE')")
+  var company: ProductPriceCompany,
+  @field:NotNull
+  @Column(name = "price_excl_tax", nullable = false, precision = 12, scale = 2)
+  var priceExclTax: BigDecimal,
+  @Column(nullable = false, length = 3)
+  var currency: String,
+) : BaseEntity()

--- a/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePrice.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePrice.kt
@@ -12,7 +12,12 @@ import org.hibernate.type.SqlTypes
 @Table(
   name = "product_purchase_prices",
   uniqueConstraints =
-    [UniqueConstraint(name = "uk_product_purchase_price_company", columnNames = ["product_id", "company"])],
+    [
+      UniqueConstraint(
+        name = "uk_product_purchase_price_company",
+        columnNames = ["product_id", "company"],
+      )
+    ],
 )
 class ProductPurchasePrice(
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -25,6 +30,5 @@ class ProductPurchasePrice(
   @field:NotNull
   @Column(name = "price_excl_tax", nullable = false, precision = 12, scale = 2)
   var priceExclTax: BigDecimal,
-  @Column(nullable = false, length = 3)
-  var currency: String,
+  @Column(nullable = false, length = 3) var currency: String,
 ) : BaseEntity()

--- a/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePriceRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePriceRepository.kt
@@ -1,0 +1,7 @@
+package fr.axl.lvy.product
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductPurchasePriceRepository : JpaRepository<ProductPurchasePrice, Long> {
+  fun findByProductIdAndCompany(productId: Long, company: ProductPriceCompany): ProductPurchasePrice?
+}

--- a/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePriceRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductPurchasePriceRepository.kt
@@ -3,5 +3,8 @@ package fr.axl.lvy.product
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProductPurchasePriceRepository : JpaRepository<ProductPurchasePrice, Long> {
-  fun findByProductIdAndCompany(productId: Long, company: ProductPriceCompany): ProductPurchasePrice?
+  fun findByProductIdAndCompany(
+    productId: Long,
+    company: ProductPriceCompany,
+  ): ProductPurchasePrice?
 }

--- a/src/main/kotlin/fr/axl/lvy/product/ProductSellingPrice.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductSellingPrice.kt
@@ -11,7 +11,12 @@ import java.math.BigDecimal
 @Table(
   name = "product_selling_prices",
   uniqueConstraints =
-    [UniqueConstraint(name = "uk_product_selling_price_client", columnNames = ["product_id", "client_id"])],
+    [
+      UniqueConstraint(
+        name = "uk_product_selling_price_client",
+        columnNames = ["product_id", "client_id"],
+      )
+    ],
 )
 class ProductSellingPrice(
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
@@ -23,6 +28,5 @@ class ProductSellingPrice(
   @field:NotNull
   @Column(name = "price_excl_tax", nullable = false, precision = 12, scale = 2)
   var priceExclTax: BigDecimal,
-  @Column(nullable = false, length = 3)
-  var currency: String,
+  @Column(nullable = false, length = 3) var currency: String,
 ) : BaseEntity()

--- a/src/main/kotlin/fr/axl/lvy/product/ProductSellingPrice.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductSellingPrice.kt
@@ -1,0 +1,28 @@
+package fr.axl.lvy.product
+
+import fr.axl.lvy.base.BaseEntity
+import fr.axl.lvy.client.Client
+import jakarta.persistence.*
+import jakarta.validation.constraints.NotNull
+import java.math.BigDecimal
+
+/** Customer-specific selling price used by CoDIG sales documents. */
+@Entity
+@Table(
+  name = "product_selling_prices",
+  uniqueConstraints =
+    [UniqueConstraint(name = "uk_product_selling_price_client", columnNames = ["product_id", "client_id"])],
+)
+class ProductSellingPrice(
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "product_id", nullable = false)
+  var product: Product,
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "client_id", nullable = false)
+  var client: Client,
+  @field:NotNull
+  @Column(name = "price_excl_tax", nullable = false, precision = 12, scale = 2)
+  var priceExclTax: BigDecimal,
+  @Column(nullable = false, length = 3)
+  var currency: String,
+) : BaseEntity()

--- a/src/main/kotlin/fr/axl/lvy/product/ProductSellingPriceRepository.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductSellingPriceRepository.kt
@@ -1,0 +1,7 @@
+package fr.axl.lvy.product
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProductSellingPriceRepository : JpaRepository<ProductSellingPrice, Long> {
+  fun findByProductIdAndClientId(productId: Long, clientId: Long): ProductSellingPrice?
+}

--- a/src/main/kotlin/fr/axl/lvy/product/ProductService.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductService.kt
@@ -1,7 +1,11 @@
 package fr.axl.lvy.product
 
 import fr.axl.lvy.client.ClientRepository
+import fr.axl.lvy.client.Client
+import fr.axl.lvy.documentline.DocumentLine
+import java.math.BigDecimal
 import java.util.Optional
+import org.hibernate.Hibernate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -14,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional
 class ProductService(
   private val productRepository: ProductRepository,
   private val productClientCodeRepository: ProductClientCodeRepository,
+  private val productPurchasePriceRepository: ProductPurchasePriceRepository,
+  private val productSellingPriceRepository: ProductSellingPriceRepository,
   private val clientRepository: ClientRepository,
 ) {
 
@@ -32,7 +38,12 @@ class ProductService(
 
   @Transactional(readOnly = true)
   fun findDetailedById(id: Long): Optional<Product> =
-    Optional.ofNullable(productRepository.findDetailedById(id))
+    Optional.ofNullable(productRepository.findDetailedById(id)).map { product ->
+      Hibernate.initialize(product.purchasePrices)
+      Hibernate.initialize(product.sellingPrices)
+      product.sellingPrices.forEach { Hibernate.initialize(it.client) }
+      product
+    }
 
   @Transactional(readOnly = true)
   fun findClientProductCode(productId: Long, clientId: Long): String? =
@@ -42,19 +53,90 @@ class ProductService(
   fun findFirstClientProductCode(productId: Long): String? =
     productClientCodeRepository.findCodesByProductId(productId).firstOrNull()
 
+  /** Resolves the unit price to prefill when a product is inserted into a document. */
+  @Transactional(readOnly = true)
+  fun resolveUnitPrice(
+    documentType: DocumentLine.DocumentType,
+    product: Product,
+    client: Client? = null,
+    usePurchasePrice: Boolean = false,
+  ): BigDecimal? =
+    when {
+      usePurchasePrice || documentType == DocumentLine.DocumentType.ORDER_CODIG ->
+        findPurchasePrice(product.id, ProductPriceCompany.CODIG)?.priceExclTax
+      documentType == DocumentLine.DocumentType.SALES_CODIG ||
+        documentType == DocumentLine.DocumentType.INVOICE_CODIG ->
+        client?.id?.let { clientId -> findSellingPrice(product.id, clientId)?.priceExclTax }
+      documentType == DocumentLine.DocumentType.SALES_NETSTONE ||
+        documentType == DocumentLine.DocumentType.ORDER_NETSTONE ||
+        documentType == DocumentLine.DocumentType.INVOICE_NETSTONE ||
+        documentType == DocumentLine.DocumentType.DELIVERY_NETSTONE ->
+        findPurchasePrice(product.id, ProductPriceCompany.NETSTONE)?.priceExclTax
+      else -> null
+    }
+
+  /** Resolves the currency that matches the unit price used for the given document context. */
+  @Transactional(readOnly = true)
+  fun resolveCurrency(
+    documentType: DocumentLine.DocumentType,
+    product: Product,
+    client: Client? = null,
+    usePurchasePrice: Boolean = false,
+  ): String? =
+    when {
+      usePurchasePrice || documentType == DocumentLine.DocumentType.ORDER_CODIG ->
+        findPurchasePrice(product.id, ProductPriceCompany.CODIG)?.currency
+      documentType == DocumentLine.DocumentType.SALES_CODIG ||
+        documentType == DocumentLine.DocumentType.INVOICE_CODIG ->
+        client?.id?.let { clientId -> findSellingPrice(product.id, clientId)?.currency }
+      documentType == DocumentLine.DocumentType.SALES_NETSTONE ||
+        documentType == DocumentLine.DocumentType.ORDER_NETSTONE ||
+        documentType == DocumentLine.DocumentType.INVOICE_NETSTONE ||
+        documentType == DocumentLine.DocumentType.DELIVERY_NETSTONE ->
+        findPurchasePrice(product.id, ProductPriceCompany.NETSTONE)?.currency
+      else -> null
+    }
+
+  /** Returns the current purchase price configured for [company]. */
+  @Transactional(readOnly = true)
+  fun findPurchasePrice(productId: Long?, company: ProductPriceCompany): ProductPurchasePrice? =
+    productId?.let { productPurchasePriceRepository.findByProductIdAndCompany(it, company) }
+
+  /** Returns the customer-specific selling price configured for [clientId]. */
+  @Transactional(readOnly = true)
+  fun findSellingPrice(productId: Long?, clientId: Long): ProductSellingPrice? =
+    productId?.let { productSellingPriceRepository.findByProductIdAndClientId(it, clientId) }
+
   @Transactional
   fun save(product: Product): Product {
-    if (product.clientProductCodes.isNotEmpty()) {
-      val managedEntries =
-        product.clientProductCodes.map { clientProductCode ->
-          clientRepository.getReferenceById(clientProductCode.client.id!!) to clientProductCode.code
+    val managedClientCodes =
+      product.clientProductCodes
+        .mapNotNull { clientProductCode ->
+          clientProductCode.client.id?.let { clientId ->
+            clientRepository.getReferenceById(clientId) to clientProductCode.code
+          }
         }
-      product.replaceClientProductCodes(managedEntries)
-    }
-    if (product.suppliers.isNotEmpty()) {
-      val managedSuppliers = product.suppliers.map { clientRepository.getReferenceById(it.id!!) }
-      product.replaceSuppliers(managedSuppliers)
-    }
+    product.replaceClientProductCodes(managedClientCodes)
+
+    val managedSuppliers = product.suppliers.mapNotNull { it.id?.let(clientRepository::getReferenceById) }
+    product.replaceSuppliers(managedSuppliers)
+
+    val purchasePriceEntries =
+      product.purchasePrices.map { Product.PurchasePriceEntry(it.company, it.priceExclTax, it.currency) }
+    product.replacePurchasePrices(purchasePriceEntries)
+
+    val sellingPriceEntries =
+      product.sellingPrices.mapNotNull { price ->
+        price.client.id?.let { clientId ->
+          Product.SellingPriceEntry(
+            clientRepository.getReferenceById(clientId),
+            price.priceExclTax,
+            price.currency,
+          )
+        }
+      }
+    product.replaceSellingPrices(sellingPriceEntries)
+
     if (product.reference.isBlank()) {
       product.reference = generateNextReference()
     }

--- a/src/main/kotlin/fr/axl/lvy/product/ProductService.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ProductService.kt
@@ -1,7 +1,7 @@
 package fr.axl.lvy.product
 
-import fr.axl.lvy.client.ClientRepository
 import fr.axl.lvy.client.Client
+import fr.axl.lvy.client.ClientRepository
 import fr.axl.lvy.documentline.DocumentLine
 import java.math.BigDecimal
 import java.util.Optional
@@ -110,19 +110,21 @@ class ProductService(
   @Transactional
   fun save(product: Product): Product {
     val managedClientCodes =
-      product.clientProductCodes
-        .mapNotNull { clientProductCode ->
-          clientProductCode.client.id?.let { clientId ->
-            clientRepository.getReferenceById(clientId) to clientProductCode.code
-          }
+      product.clientProductCodes.mapNotNull { clientProductCode ->
+        clientProductCode.client.id?.let { clientId ->
+          clientRepository.getReferenceById(clientId) to clientProductCode.code
         }
+      }
     product.replaceClientProductCodes(managedClientCodes)
 
-    val managedSuppliers = product.suppliers.mapNotNull { it.id?.let(clientRepository::getReferenceById) }
+    val managedSuppliers =
+      product.suppliers.mapNotNull { it.id?.let(clientRepository::getReferenceById) }
     product.replaceSuppliers(managedSuppliers)
 
     val purchasePriceEntries =
-      product.purchasePrices.map { Product.PurchasePriceEntry(it.company, it.priceExclTax, it.currency) }
+      product.purchasePrices.map {
+        Product.PurchasePriceEntry(it.company, it.priceExclTax, it.currency)
+      }
     product.replacePurchasePrices(purchasePriceEntries)
 
     val sellingPriceEntries =

--- a/src/main/kotlin/fr/axl/lvy/product/ui/ProductFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ui/ProductFormDialog.kt
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.combobox.ComboBox
 import com.vaadin.flow.component.combobox.MultiSelectComboBox
 import com.vaadin.flow.component.dialog.Dialog
 import com.vaadin.flow.component.formlayout.FormLayout
+import com.vaadin.flow.component.html.H4
 import com.vaadin.flow.component.notification.Notification
 import com.vaadin.flow.component.notification.NotificationVariant
 import com.vaadin.flow.component.orderedlayout.FlexComponent
@@ -20,6 +21,7 @@ import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientService
 import fr.axl.lvy.currency.CurrencyService
 import fr.axl.lvy.product.Product
+import fr.axl.lvy.product.ProductPriceCompany
 import fr.axl.lvy.product.ProductService
 import java.math.BigDecimal
 import org.slf4j.LoggerFactory
@@ -38,12 +40,7 @@ internal class ProductFormDialog(
   private val longDescription = TextArea("Description longue")
   private val specifications = TextArea("Spécifications")
   private val type = ComboBox<Product.ProductType>("Type")
-  private val priceType = TextField("Conditions prix achat")
   private val mto = Checkbox("Fabrication sur commande (MTO)")
-  private val sellingPrice = BigDecimalField("Prix vente HT")
-  private val sellingCurrency = Select<String>()
-  private val purchasePrice = BigDecimalField("Prix achat HT")
-  private val purchaseCurrency = Select<String>()
   private val suppliers = MultiSelectComboBox<Client>("Fournisseurs")
   private val unitOption = ComboBox<String>("Unité")
   private val customUnit = TextField("Autre unité")
@@ -53,27 +50,30 @@ internal class ProductFormDialog(
   private val madeIn = ComboBox<String>("Origine")
   private val active = Checkbox("Actif")
   private val clientCodeRows = VerticalLayout()
+  private val purchasePriceSection = FormLayout()
+  private val codigPurchasePrice = BigDecimalField("Prix achat CoDIG HT")
+  private val codigPurchaseCurrency = Select<String>()
+  private val netstonePurchasePrice = BigDecimalField("Prix achat Netstone HT")
+  private val netstonePurchaseCurrency = Select<String>()
+  private val sellingPriceRows = VerticalLayout()
   private val availableClients: List<Client> = clientService.findClients()
   private val availableSuppliers: List<Client> =
     clientService.findByRole(Client.ClientRole.PRODUCER)
   private val clientCodeEntries = mutableListOf<ClientCodeRow>()
+  private val sellingPriceEntries = mutableListOf<SellingPriceRow>()
+  private val currencyCodes = currencyService.findAll().map { it.code }
 
   init {
     setHeaderTitle(if (product == null) "Nouveau produit" else "Modifier produit")
-    setWidth("760px")
+    setWidth("920px")
 
     type.setItems(*Product.ProductType.entries.toTypedArray())
     type.setItemLabelGenerator { if (it == Product.ProductType.PRODUCT) "Produit" else "Service" }
     type.addValueChangeListener { e -> updateFieldsForType(e.value) }
-    val currencyCodes = currencyService.findAll().map { it.code }
-    sellingCurrency.label = "Devise vente"
-    sellingCurrency.setItems(currencyCodes)
-    sellingCurrency.value = "EUR"
-    purchaseCurrency.label = "Devise achat"
-    purchaseCurrency.setItems(currencyCodes)
-    purchaseCurrency.value = "EUR"
     suppliers.setItems(availableSuppliers)
     suppliers.setItemLabelGenerator { it.name }
+    configureCurrencySelect(codigPurchaseCurrency, "Devise achat CoDIG")
+    configureCurrencySelect(netstonePurchaseCurrency, "Devise achat Netstone")
 
     unitOption.setItems(UNIT_MT, UNIT_KG, UNIT_OTHER)
     customUnit.placeholder = "Saisir l'unité"
@@ -93,22 +93,40 @@ internal class ProductFormDialog(
     form.add(label, 2)
     form.add(shortDescription, 2)
     form.add(longDescription, 2)
-    form.add(priceType, mto)
+    form.add(mto, 2)
     form.add(specifications, 2)
     form.add(unitOption, customUnit)
-    form.add(sellingPrice, sellingCurrency)
-    form.add(purchasePrice, purchaseCurrency)
     form.add(suppliers, 2)
     form.add(hsCode, casNumber)
     form.add(ecNumber, madeIn)
     form.add(active)
+
+    purchasePriceSection.setResponsiveSteps(FormLayout.ResponsiveStep("0", 2))
+    purchasePriceSection.add(codigPurchasePrice, codigPurchaseCurrency)
+    purchasePriceSection.add(netstonePurchasePrice, netstonePurchaseCurrency)
 
     val addClientCodeButton = Button("Ajouter code client") { addClientCodeRow() }
     val clientCodesSection = VerticalLayout(addClientCodeButton, clientCodeRows)
     clientCodesSection.isPadding = false
     clientCodesSection.isSpacing = true
 
-    add(VerticalLayout(form, clientCodesSection).apply { isPadding = false })
+    val addSellingPriceButton = Button("Ajouter prix client") { addSellingPriceRow() }
+    val sellingPricesSection = VerticalLayout(addSellingPriceButton, sellingPriceRows)
+    sellingPricesSection.isPadding = false
+    sellingPricesSection.isSpacing = true
+
+    add(
+      VerticalLayout(
+          form,
+          H4("Prix d'achat"),
+          purchasePriceSection,
+          H4("Prix de vente CoDIG par client"),
+          sellingPricesSection,
+          H4("Codes produit client"),
+          clientCodesSection,
+        )
+        .apply { isPadding = false }
+    )
 
     val saveBtn = Button("Enregistrer") { save() }
     saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
@@ -120,6 +138,8 @@ internal class ProductFormDialog(
     } else {
       type.value = Product.ProductType.PRODUCT
       active.value = true
+      codigPurchaseCurrency.value = "EUR"
+      netstonePurchaseCurrency.value = "EUR"
     }
   }
 
@@ -130,12 +150,7 @@ internal class ProductFormDialog(
     longDescription.value = p.longDescription ?: ""
     specifications.value = p.specifications ?: ""
     type.value = p.type
-    priceType.value = p.priceType ?: ""
     mto.value = p.mto
-    sellingPrice.value = p.sellingPriceExclTax
-    sellingCurrency.value = p.sellingCurrency
-    purchasePrice.value = p.purchasePriceExclTax
-    purchaseCurrency.value = p.purchaseCurrency
     suppliers.select(p.suppliers)
     applyUnitValue(p.type, p.unit)
     hsCode.value = p.hsCode ?: ""
@@ -143,6 +158,19 @@ internal class ProductFormDialog(
     ecNumber.value = p.ecNumber ?: ""
     madeIn.value = p.madeIn
     active.value = p.active
+    p.purchasePrices.forEach { price ->
+      when (price.company) {
+        ProductPriceCompany.CODIG -> {
+          codigPurchasePrice.value = price.priceExclTax
+          codigPurchaseCurrency.value = price.currency
+        }
+        ProductPriceCompany.NETSTONE -> {
+          netstonePurchasePrice.value = price.priceExclTax
+          netstonePurchaseCurrency.value = price.currency
+        }
+      }
+    }
+    p.sellingPrices.forEach { addSellingPriceRow(it.client, it.priceExclTax, it.currency) }
     p.clientProductCodes.forEach { addClientCodeRow(it.client, it.code) }
     updateFieldsForType(p.type)
   }
@@ -170,6 +198,18 @@ internal class ProductFormDialog(
       return
     }
 
+    val duplicateSellingPrices =
+      collectSellingPrices().groupingBy { it.client.id }.eachCount().filterValues { it > 1 }
+    if (duplicateSellingPrices.isNotEmpty()) {
+      Notification.show(
+          "Chaque client ne peut avoir qu'un seul prix de vente",
+          3000,
+          Notification.Position.BOTTOM_END,
+        )
+        .addThemeVariants(NotificationVariant.LUMO_ERROR)
+      return
+    }
+
     try {
       val p = product ?: Product(name = name.value)
       p.name = name.value
@@ -178,12 +218,7 @@ internal class ProductFormDialog(
       p.longDescription = longDescription.value.takeIf { it.isNotBlank() }
       p.specifications = if (specifications.value.isBlank()) null else specifications.value
       p.type = type.value
-      p.priceType = priceType.value.takeIf { it.isNotBlank() }
       p.mto = type.value == Product.ProductType.PRODUCT && mto.value
-      p.sellingPriceExclTax = sellingPrice.value ?: BigDecimal.ZERO
-      p.sellingCurrency = sellingCurrency.value ?: "EUR"
-      p.purchasePriceExclTax = purchasePrice.value ?: BigDecimal.ZERO
-      p.purchaseCurrency = purchaseCurrency.value ?: "EUR"
       p.unit = resolveUnitValue()
       p.hsCode = if (hsCode.value.isBlank()) null else hsCode.value
       p.casNumber = casNumber.value.takeIf { it.isNotBlank() }
@@ -191,6 +226,8 @@ internal class ProductFormDialog(
       p.madeIn = madeIn.value
       p.replaceClientProductCodes(collectClientCodes())
       p.replaceSuppliers(suppliers.selectedItems)
+      p.replacePurchasePrices(collectPurchasePrices())
+      p.replaceSellingPrices(collectSellingPrices())
       p.active = active.value
 
       productService.save(p)
@@ -257,6 +294,79 @@ internal class ProductFormDialog(
     return null
   }
 
+  private fun configureCurrencySelect(select: Select<String>, label: String) {
+    select.label = label
+    select.setItems(currencyCodes)
+    select.value = "EUR"
+  }
+
+  private fun collectPurchasePrices(): List<Product.PurchasePriceEntry> =
+    buildList {
+      codigPurchasePrice.value?.let { price ->
+        add(
+          Product.PurchasePriceEntry(
+            ProductPriceCompany.CODIG,
+            price,
+            codigPurchaseCurrency.value ?: "EUR",
+          )
+        )
+      }
+      netstonePurchasePrice.value?.let { price ->
+        add(
+          Product.PurchasePriceEntry(
+            ProductPriceCompany.NETSTONE,
+            price,
+            netstonePurchaseCurrency.value ?: "EUR",
+          )
+        )
+      }
+    }
+
+  private fun addSellingPriceRow(
+    client: Client? = null,
+    price: BigDecimal? = null,
+    currency: String = "EUR",
+  ) {
+    val clientCombo = ComboBox<Client>("Client")
+    clientCombo.setItems(availableClients)
+    clientCombo.setItemLabelGenerator { "${it.clientCode} - ${it.name}" }
+    clientCombo.value = client
+
+    val priceField = BigDecimalField("Prix vente HT")
+    priceField.value = price
+
+    val currencySelect = Select<String>()
+    configureCurrencySelect(currencySelect, "Devise vente")
+    currencySelect.value = currency
+
+    val removeButton = Button("Supprimer")
+    removeButton.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_TERTIARY)
+
+    val row = HorizontalLayout(clientCombo, priceField, currencySelect, removeButton)
+    row.width = "100%"
+    row.defaultVerticalComponentAlignment = FlexComponent.Alignment.END
+    row.setFlexGrow(1.0, clientCombo)
+
+    val entry = SellingPriceRow(row, clientCombo, priceField, currencySelect)
+    sellingPriceEntries.add(entry)
+    removeButton.addClickListener {
+      sellingPriceEntries.remove(entry)
+      sellingPriceRows.remove(row)
+    }
+    sellingPriceRows.add(row)
+  }
+
+  private fun collectSellingPrices(): List<Product.SellingPriceEntry> =
+    sellingPriceEntries.mapNotNull { entry ->
+      val client = entry.clientCombo.value
+      val price = entry.priceField.value
+      if (client != null && price != null) {
+        Product.SellingPriceEntry(client, price, entry.currencySelect.value ?: "EUR")
+      } else {
+        null
+      }
+    }
+
   companion object {
     private val logger = LoggerFactory.getLogger(ProductFormDialog::class.java)
     private const val UNIT_MT = "Mt"
@@ -303,5 +413,12 @@ internal class ProductFormDialog(
     val row: HorizontalLayout,
     val clientCombo: ComboBox<Client>,
     val codeField: TextField,
+  )
+
+  private class SellingPriceRow(
+    val row: HorizontalLayout,
+    val clientCombo: ComboBox<Client>,
+    val priceField: BigDecimalField,
+    val currencySelect: Select<String>,
   )
 }

--- a/src/main/kotlin/fr/axl/lvy/product/ui/ProductFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ui/ProductFormDialog.kt
@@ -300,27 +300,26 @@ internal class ProductFormDialog(
     select.value = "EUR"
   }
 
-  private fun collectPurchasePrices(): List<Product.PurchasePriceEntry> =
-    buildList {
-      codigPurchasePrice.value?.let { price ->
-        add(
-          Product.PurchasePriceEntry(
-            ProductPriceCompany.CODIG,
-            price,
-            codigPurchaseCurrency.value ?: "EUR",
-          )
+  private fun collectPurchasePrices(): List<Product.PurchasePriceEntry> = buildList {
+    codigPurchasePrice.value?.let { price ->
+      add(
+        Product.PurchasePriceEntry(
+          ProductPriceCompany.CODIG,
+          price,
+          codigPurchaseCurrency.value ?: "EUR",
         )
-      }
-      netstonePurchasePrice.value?.let { price ->
-        add(
-          Product.PurchasePriceEntry(
-            ProductPriceCompany.NETSTONE,
-            price,
-            netstonePurchaseCurrency.value ?: "EUR",
-          )
-        )
-      }
+      )
     }
+    netstonePurchasePrice.value?.let { price ->
+      add(
+        Product.PurchasePriceEntry(
+          ProductPriceCompany.NETSTONE,
+          price,
+          netstonePurchaseCurrency.value ?: "EUR",
+        )
+      )
+    }
+  }
 
   private fun addSellingPriceRow(
     client: Client? = null,

--- a/src/main/kotlin/fr/axl/lvy/product/ui/ProductListView.kt
+++ b/src/main/kotlin/fr/axl/lvy/product/ui/ProductListView.kt
@@ -33,17 +33,12 @@ internal class ProductListView(
     addBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
 
     grid = Grid()
+    grid.addColumn(Product::reference).setHeader("Référence").setAutoWidth(true)
     grid.addColumn(Product::name).setHeader("Nom").setFlexGrow(1)
     grid.addColumn { it.type.name }.setHeader("Type").setAutoWidth(true)
-    grid.addColumn { it.priceType ?: "" }.setHeader("Conditions prix achat").setAutoWidth(true)
-    grid
-      .addColumn { "${it.sellingPriceExclTax} ${it.sellingCurrency}" }
-      .setHeader("Prix vente HT")
-      .setAutoWidth(true)
-    grid
-      .addColumn { "${it.purchasePriceExclTax} ${it.purchaseCurrency}" }
-      .setHeader("Prix achat HT")
-      .setAutoWidth(true)
+    grid.addColumn { it.hsCode ?: "" }.setHeader("Code HS").setAutoWidth(true)
+    grid.addColumn { it.casNumber ?: "" }.setHeader("CAS").setAutoWidth(true)
+    grid.addColumn { it.ecNumber ?: "" }.setHeader("EC").setAutoWidth(true)
     grid.addColumn { if (it.active) "Actif" else "Inactif" }.setHeader("Statut").setAutoWidth(true)
     grid
       .addComponentColumn { product ->

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
@@ -6,6 +6,8 @@ import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineService
 import fr.axl.lvy.order.OrderCodig
 import fr.axl.lvy.order.OrderCodigService
+import fr.axl.lvy.product.ProductPriceCompany
+import fr.axl.lvy.product.ProductService
 import io.micrometer.core.instrument.MeterRegistry
 import java.math.BigDecimal
 import java.util.Optional
@@ -30,6 +32,7 @@ class SalesCodigService(
   private val numberSequenceService: NumberSequenceService,
   private val meterRegistry: MeterRegistry,
   private val clientService: ClientService,
+  private val productService: ProductService,
 ) {
   private val salesCreatedCounter = meterRegistry.counter("sale.codig")
 
@@ -153,12 +156,18 @@ class SalesCodigService(
     order.status = OrderCodig.OrderCodigStatus.DRAFT
 
     val savedOrder = orderCodigService.save(order)
+    val purchaseCurrency = firstPurchaseCurrency(saleLines, ProductPriceCompany.CODIG)
+    if (!purchaseCurrency.isNullOrBlank()) {
+      savedOrder.currency = purchaseCurrency
+    }
     val generatedLines =
       documentLineService.replaceLines(
         DocumentLine.DocumentType.ORDER_CODIG,
         savedOrder.id!!,
         saleLines,
-        overrideUnitPrice = { it.product?.purchasePriceExclTax },
+        overrideUnitPrice = { line ->
+          productService.findPurchasePrice(line.product?.id, ProductPriceCompany.CODIG)?.priceExclTax
+        },
       )
 
     savedOrder.recalculateTotals(generatedLines)
@@ -193,14 +202,28 @@ class SalesCodigService(
     val persistedLines =
       documentLineService.replaceLines(DocumentLine.DocumentType.SALES_CODIG, saved.id!!, lines)
 
-    saved.purchasePriceExclTax =
-      persistedLines.fold(BigDecimal.ZERO) { acc, line ->
-        acc.add((line.product?.purchasePriceExclTax ?: BigDecimal.ZERO).multiply(line.quantity))
-      }
+    saved.purchasePriceExclTax = computePurchaseTotal(persistedLines, ProductPriceCompany.CODIG)
     saved.recalculateTotals(persistedLines)
     return syncGeneratedOrder(saved, persistedLines)
   }
 
+  private fun computePurchaseTotal(
+    lines: List<DocumentLine>,
+    company: ProductPriceCompany,
+  ): BigDecimal =
+    lines.fold(BigDecimal.ZERO) { acc, line ->
+      val price = productService.findPurchasePrice(line.product?.id, company)?.priceExclTax ?: BigDecimal.ZERO
+      acc.add(price.multiply(line.quantity))
+    }
+
   private fun generateNextSaleNumber(): String =
     numberSequenceService.nextNumber(NumberSequenceService.SALES_CODIG)
+
+  private fun firstPurchaseCurrency(
+    lines: List<DocumentLine>,
+    company: ProductPriceCompany,
+  ): String? =
+    lines.firstNotNullOfOrNull { line ->
+      productService.findPurchasePrice(line.product?.id, company)?.currency
+    }
 }

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesCodigService.kt
@@ -166,7 +166,9 @@ class SalesCodigService(
         savedOrder.id!!,
         saleLines,
         overrideUnitPrice = { line ->
-          productService.findPurchasePrice(line.product?.id, ProductPriceCompany.CODIG)?.priceExclTax
+          productService
+            .findPurchasePrice(line.product?.id, ProductPriceCompany.CODIG)
+            ?.priceExclTax
         },
       )
 
@@ -212,7 +214,8 @@ class SalesCodigService(
     company: ProductPriceCompany,
   ): BigDecimal =
     lines.fold(BigDecimal.ZERO) { acc, line ->
-      val price = productService.findPurchasePrice(line.product?.id, company)?.priceExclTax ?: BigDecimal.ZERO
+      val price =
+        productService.findPurchasePrice(line.product?.id, company)?.priceExclTax ?: BigDecimal.ZERO
       acc.add(price.multiply(line.quantity))
     }
 

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneService.kt
@@ -6,6 +6,7 @@ import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineService
 import fr.axl.lvy.order.OrderNetstone
 import fr.axl.lvy.order.OrderNetstoneService
+import fr.axl.lvy.product.ProductPriceCompany
 import fr.axl.lvy.product.ProductService
 import io.micrometer.core.instrument.MeterRegistry
 import java.math.BigDecimal
@@ -122,11 +123,6 @@ class SalesNetstoneService(
     sale.paymentTerm = sourceOrderCodig.paymentTerm
     sale.currency = sourceOrderCodig.currency
     sale.exchangeRate = sourceOrderCodig.exchangeRate
-    sale.purchasePriceExclTax =
-      sourceLines.fold(BigDecimal.ZERO) { acc, line ->
-        acc.add((line.product?.purchasePriceExclTax ?: BigDecimal.ZERO).multiply(line.quantity))
-      }
-
     val savedSale = save(sale)
 
     val generatedSaleLines =
@@ -134,10 +130,15 @@ class SalesNetstoneService(
         DocumentLine.DocumentType.SALES_NETSTONE,
         savedSale.id!!,
         sourceLines,
+        overrideUnitPrice = { line ->
+          productService.findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)?.priceExclTax
+        },
         overrideDiscountPercent = BigDecimal.ZERO,
         filter = { it.product?.isMtoProduct() == true },
       )
 
+    firstPurchaseCurrency(generatedSaleLines)?.let { savedSale.currency = it }
+    savedSale.purchasePriceExclTax = computeLineTotal(generatedSaleLines)
     savedSale.recalculateTotals(generatedSaleLines)
     val result = salesNetstoneRepository.save(savedSale)
 
@@ -245,6 +246,7 @@ class SalesNetstoneService(
     val persistedLines =
       documentLineService.replaceLines(DocumentLine.DocumentType.SALES_NETSTONE, saved.id!!, lines)
 
+    saved.purchasePriceExclTax = computeLineTotal(persistedLines)
     saved.recalculateTotals(persistedLines)
     if (
       saved.status == SalesStatus.VALIDATED &&
@@ -264,4 +266,12 @@ class SalesNetstoneService(
 
   private fun generateNextSaleNumber(): String =
     numberSequenceService.nextNumber(NumberSequenceService.SALES_NETSTONE)
+
+  private fun computeLineTotal(lines: List<DocumentLine>): BigDecimal =
+    lines.fold(BigDecimal.ZERO) { acc, line -> acc.add(line.unitPriceExclTax.multiply(line.quantity)) }
+
+  private fun firstPurchaseCurrency(lines: List<DocumentLine>): String? =
+    lines.firstNotNullOfOrNull { line ->
+      productService.findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)?.currency
+    }
 }

--- a/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneService.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/SalesNetstoneService.kt
@@ -131,7 +131,9 @@ class SalesNetstoneService(
         savedSale.id!!,
         sourceLines,
         overrideUnitPrice = { line ->
-          productService.findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)?.priceExclTax
+          productService
+            .findPurchasePrice(line.product?.id, ProductPriceCompany.NETSTONE)
+            ?.priceExclTax
         },
         overrideDiscountPercent = BigDecimal.ZERO,
         filter = { it.product?.isMtoProduct() == true },
@@ -268,7 +270,9 @@ class SalesNetstoneService(
     numberSequenceService.nextNumber(NumberSequenceService.SALES_NETSTONE)
 
   private fun computeLineTotal(lines: List<DocumentLine>): BigDecimal =
-    lines.fold(BigDecimal.ZERO) { acc, line -> acc.add(line.unitPriceExclTax.multiply(line.quantity)) }
+    lines.fold(BigDecimal.ZERO) { acc, line ->
+      acc.add(line.unitPriceExclTax.multiply(line.quantity))
+    }
 
   private fun firstPurchaseCurrency(lines: List<DocumentLine>): String? =
     lines.firstNotNullOfOrNull { line ->

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigFormDialog.kt
@@ -149,7 +149,12 @@ internal class SalesCodigFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateSalesCodigPdf(order.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesCodigFormDialog.kt
@@ -13,7 +13,8 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout
 import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.DocumentFlowNavigation
 import fr.axl.lvy.base.ui.DocumentFlowNavigator
 import fr.axl.lvy.base.ui.DocumentFlowStep
@@ -35,6 +36,7 @@ import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodig
 import fr.axl.lvy.sale.SalesCodigService
 import fr.axl.lvy.sale.SalesStatus
+import java.io.ByteArrayInputStream
 import java.math.BigDecimal
 import java.time.LocalDate
 import org.slf4j.LoggerFactory
@@ -143,17 +145,14 @@ internal class SalesCodigFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (order?.id != null) {
-      val pdfResource =
-        StreamResource("${order.saleNumber.replace("/", "_")}.pdf") {
-            pdfService.generateSalesCodigPdf(order.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${order.saleNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateSalesCodigPdf(order.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
@@ -155,7 +155,12 @@ internal class SalesNetstoneFormDialog(
       val pdfHandler =
         DownloadHandler.fromInputStream {
           val bytes = pdfService.generateSalesNetstonePdf(order.id!!)
-          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
+          DownloadResponse(
+            ByteArrayInputStream(bytes),
+            fileName,
+            "application/pdf",
+            bytes.size.toLong(),
+          )
         }
       val pdfBtn = Button("Télécharger PDF")
       val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }

--- a/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
+++ b/src/main/kotlin/fr/axl/lvy/sale/ui/SalesNetstoneFormDialog.kt
@@ -14,7 +14,8 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout
 import com.vaadin.flow.component.textfield.TextArea
 import com.vaadin.flow.component.textfield.TextField
 import com.vaadin.flow.data.provider.DataProvider
-import com.vaadin.flow.server.StreamResource
+import com.vaadin.flow.server.streams.DownloadHandler
+import com.vaadin.flow.server.streams.DownloadResponse
 import fr.axl.lvy.base.ui.DocumentFlowNavigation
 import fr.axl.lvy.base.ui.DocumentFlowNavigator
 import fr.axl.lvy.base.ui.DocumentFlowStep
@@ -38,6 +39,7 @@ import fr.axl.lvy.sale.SalesCodigService
 import fr.axl.lvy.sale.SalesNetstone
 import fr.axl.lvy.sale.SalesNetstoneService
 import fr.axl.lvy.sale.SalesStatus
+import java.io.ByteArrayInputStream
 
 internal class SalesNetstoneFormDialog(
   private val salesNetstoneService: SalesNetstoneService,
@@ -149,17 +151,14 @@ internal class SalesNetstoneFormDialog(
     val cancelBtn = Button("Annuler") { close() }
     val footerLayout = HorizontalLayout(saveBtn, cancelBtn)
     if (order?.id != null) {
-      val pdfResource =
-        StreamResource("${order.saleNumber.replace("/", "_")}.pdf") {
-            pdfService.generateSalesNetstonePdf(order.id!!).inputStream()
-          }
-          .apply { cacheTime = 0 }
-      val pdfBtn = Button("Télécharger PDF")
-      val pdfLink =
-        Anchor(pdfResource, "").apply {
-          element.setAttribute("download", true)
-          add(pdfBtn)
+      val fileName = "${order.saleNumber.replace("/", "_")}.pdf"
+      val pdfHandler =
+        DownloadHandler.fromInputStream {
+          val bytes = pdfService.generateSalesNetstonePdf(order.id!!)
+          DownloadResponse(ByteArrayInputStream(bytes), fileName, "application/pdf", bytes.size.toLong())
         }
+      val pdfBtn = Button("Télécharger PDF")
+      val pdfLink = Anchor(pdfHandler, "").apply { add(pdfBtn) }
       footerLayout.add(pdfLink)
     }
     footer.add(footerLayout)

--- a/src/main/kotlin/fr/axl/lvy/seed/DatabaseSeeder.kt
+++ b/src/main/kotlin/fr/axl/lvy/seed/DatabaseSeeder.kt
@@ -14,6 +14,7 @@ import fr.axl.lvy.incoterm.IncotermService
 import fr.axl.lvy.paymentterm.PaymentTerm
 import fr.axl.lvy.paymentterm.PaymentTermService
 import fr.axl.lvy.product.Product
+import fr.axl.lvy.product.ProductPriceCompany
 import fr.axl.lvy.product.ProductService
 import fr.axl.lvy.sale.SalesCodig
 import fr.axl.lvy.sale.SalesCodigService
@@ -301,34 +302,63 @@ class DatabaseSeeder(
           type = Product.ProductType.PRODUCT
           mto = true
           specifications = "AMPS 2403 MONOMER, NEA SAP R3 SPECIFICATION: 1007623"
-          sellingPriceExclTax = BigDecimal("49.99")
-          sellingCurrency = "USD"
-          purchasePriceExclTax = BigDecimal("25.00")
-          purchaseCurrency = "USD"
           unit = "Mt"
           hsCode = "9031.80"
           madeIn = "China"
           replaceClientProductCodes(listOf(dowChemical to "10041948", dupont to "DUP-CO3104-CN"))
+          replacePurchasePrices(
+            listOf(
+              Product.PurchasePriceEntry(
+                ProductPriceCompany.CODIG,
+                BigDecimal("25.00"),
+                "USD",
+              ),
+              Product.PurchasePriceEntry(
+                ProductPriceCompany.NETSTONE,
+                BigDecimal("22.00"),
+                "USD",
+              ),
+            )
+          )
+          replaceSellingPrices(
+            listOf(
+              Product.SellingPriceEntry(dowChemical, BigDecimal("49.99"), "USD"),
+              Product.SellingPriceEntry(dupont, BigDecimal("53.00"), "USD"),
+            )
+          )
         },
         Product(name = "CO_3104 TH").apply {
           type = Product.ProductType.PRODUCT
           mto = true
           specifications = "AMPS 2403 MONOMER, NEA SAP R3 SPECIFICATION: 1007623"
-          sellingPriceExclTax = BigDecimal("89.99")
-          sellingCurrency = "USD"
-          purchasePriceExclTax = BigDecimal("45.00")
-          purchaseCurrency = "USD"
           unit = "Mt"
           hsCode = "9031.80.234"
           madeIn = "Thailand"
           replaceClientProductCodes(listOf(dowChemical to "10041948", dupont to "DUP-CO3104-TH"))
+          replacePurchasePrices(
+            listOf(
+              Product.PurchasePriceEntry(
+                ProductPriceCompany.CODIG,
+                BigDecimal("45.00"),
+                "USD",
+              ),
+              Product.PurchasePriceEntry(
+                ProductPriceCompany.NETSTONE,
+                BigDecimal("41.00"),
+                "USD",
+              ),
+            )
+          )
+          replaceSellingPrices(
+            listOf(
+              Product.SellingPriceEntry(dowChemical, BigDecimal("89.99"), "USD"),
+              Product.SellingPriceEntry(dupont, BigDecimal("94.50"), "USD"),
+            )
+          )
         },
         Product(name = "Demurrage").apply {
           type = Product.ProductType.SERVICE
-          sellingPriceExclTax = BigDecimal("150.00")
-          sellingCurrency = "USD"
-          purchasePriceExclTax = BigDecimal.ZERO
-          purchaseCurrency = "USD"
+          replaceSellingPrices(listOf(Product.SellingPriceEntry(dowChemical, BigDecimal("150.00"), "USD")))
         },
       )
 

--- a/src/main/kotlin/fr/axl/lvy/seed/DatabaseSeeder.kt
+++ b/src/main/kotlin/fr/axl/lvy/seed/DatabaseSeeder.kt
@@ -28,6 +28,8 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
+private const val THE_DOW_CHEMICAL_COMPANY = "THE DOW CHEMICAL COMPANY"
+
 /**
  * Seeds a lightweight local dataset: reference tables, users, companies/clients, and products.
  *
@@ -211,7 +213,7 @@ class DatabaseSeeder(
           billingAddress =
             "10/F., Guangdong Investment Tower\n148 Connaught Road\nCentral, Hong Kong"
         },
-        Client(name = "THE DOW CHEMICAL COMPANY").apply {
+        Client(name = THE_DOW_CHEMICAL_COMPANY).apply {
           type = Client.ClientType.COMPANY
           role = Client.ClientRole.CLIENT
           visibleCompany = User.Company.CODIG
@@ -291,7 +293,7 @@ class DatabaseSeeder(
 
     val clientsByName = clientService.findAll().associateBy { it.name }
     val dowChemical =
-      checkNotNull(clientsByName["THE DOW CHEMICAL COMPANY"]?.id).let { clientId ->
+      checkNotNull(clientsByName[THE_DOW_CHEMICAL_COMPANY]?.id).let { clientId ->
         clientService.findDetailedById(clientId).orElseThrow()
       }
     val dupont = checkNotNull(clientsByName["Dupont"])
@@ -308,16 +310,8 @@ class DatabaseSeeder(
           replaceClientProductCodes(listOf(dowChemical to "10041948", dupont to "DUP-CO3104-CN"))
           replacePurchasePrices(
             listOf(
-              Product.PurchasePriceEntry(
-                ProductPriceCompany.CODIG,
-                BigDecimal("25.00"),
-                "USD",
-              ),
-              Product.PurchasePriceEntry(
-                ProductPriceCompany.NETSTONE,
-                BigDecimal("22.00"),
-                "USD",
-              ),
+              Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("25.00"), "USD"),
+              Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("22.00"), "USD"),
             )
           )
           replaceSellingPrices(
@@ -337,16 +331,8 @@ class DatabaseSeeder(
           replaceClientProductCodes(listOf(dowChemical to "10041948", dupont to "DUP-CO3104-TH"))
           replacePurchasePrices(
             listOf(
-              Product.PurchasePriceEntry(
-                ProductPriceCompany.CODIG,
-                BigDecimal("45.00"),
-                "USD",
-              ),
-              Product.PurchasePriceEntry(
-                ProductPriceCompany.NETSTONE,
-                BigDecimal("41.00"),
-                "USD",
-              ),
+              Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("45.00"), "USD"),
+              Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("41.00"), "USD"),
             )
           )
           replaceSellingPrices(
@@ -358,7 +344,9 @@ class DatabaseSeeder(
         },
         Product(name = "Demurrage").apply {
           type = Product.ProductType.SERVICE
-          replaceSellingPrices(listOf(Product.SellingPriceEntry(dowChemical, BigDecimal("150.00"), "USD")))
+          replaceSellingPrices(
+            listOf(Product.SellingPriceEntry(dowChemical, BigDecimal("150.00"), "USD"))
+          )
         },
       )
 
@@ -376,7 +364,7 @@ class DatabaseSeeder(
     val productsByName = productService.findAll().associateBy { it.name }
 
     val dowChemical =
-      checkNotNull(clientsByName["THE DOW CHEMICAL COMPANY"]?.id).let { clientId ->
+      checkNotNull(clientsByName[THE_DOW_CHEMICAL_COMPANY]?.id).let { clientId ->
         clientService.findDetailedById(clientId).orElseThrow()
       }
     val product =

--- a/src/test/kotlin/fr/axl/lvy/TestDataFactory.kt
+++ b/src/test/kotlin/fr/axl/lvy/TestDataFactory.kt
@@ -5,6 +5,7 @@ import fr.axl.lvy.client.ClientRepository
 import fr.axl.lvy.documentline.DocumentLine
 import fr.axl.lvy.documentline.DocumentLineRepository
 import fr.axl.lvy.product.Product
+import fr.axl.lvy.product.ProductPriceCompany
 import fr.axl.lvy.product.ProductRepository
 import java.math.BigDecimal
 import org.springframework.stereotype.Component
@@ -53,6 +54,12 @@ class TestDataFactory(
     product.mto = true
     product.sellingPriceExclTax = BigDecimal("100.00")
     product.purchasePriceExclTax = BigDecimal("60.00")
+    product.replacePurchasePrices(
+      listOf(
+        Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("60.00"), "EUR"),
+        Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("60.00"), "EUR"),
+      )
+    )
     return productRepository.saveAndFlush(product)
   }
 
@@ -62,6 +69,12 @@ class TestDataFactory(
     product.mto = false
     product.sellingPriceExclTax = BigDecimal("50.00")
     product.purchasePriceExclTax = BigDecimal("30.00")
+    product.replacePurchasePrices(
+      listOf(
+        Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("30.00"), "EUR"),
+        Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("30.00"), "EUR"),
+      )
+    )
     return productRepository.saveAndFlush(product)
   }
 }

--- a/src/test/kotlin/fr/axl/lvy/documentline/DocumentLineTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/documentline/DocumentLineTest.kt
@@ -65,18 +65,18 @@ class DocumentLineTest {
     val line = DocumentLine.fromProduct(DocumentLine.DocumentType.ORDER_CODIG, 1L, product, client)
 
     assertThat(line.designation).isEqualTo("Steel Beam")
-    assertThat(line.unitPriceExclTax).isEqualByComparingTo("150.00")
+    assertThat(line.unitPriceExclTax).isEqualByComparingTo("0")
     assertThat(line.unit).isEqualTo("kg")
     assertThat(line.hsCode).isEqualTo("7216.10")
     assertThat(line.madeIn).isEqualTo("France")
     assertThat(line.clientProductCode).isEqualTo("CL-BEAM-01")
     assertThat(line.quantity).isEqualByComparingTo("1")
     assertThat(line.discountPercent).isEqualByComparingTo("0")
-    assertThat(line.lineTotalExclTax).isEqualByComparingTo("150.00")
+    assertThat(line.lineTotalExclTax).isEqualByComparingTo("0")
   }
 
   @Test
-  fun fromProduct_can_use_purchase_price() {
+  fun fromProduct_initializes_unit_price_to_zero() {
     val product = Product("REF-BUY", "Purchased Product")
     product.sellingPriceExclTax = BigDecimal("150.00")
     product.purchasePriceExclTax = BigDecimal("80.00")
@@ -89,8 +89,8 @@ class DocumentLineTest {
         usePurchasePrice = true,
       )
 
-    assertThat(line.unitPriceExclTax).isEqualByComparingTo("80.00")
-    assertThat(line.lineTotalExclTax).isEqualByComparingTo("80.00")
+    assertThat(line.unitPriceExclTax).isEqualByComparingTo("0")
+    assertThat(line.lineTotalExclTax).isEqualByComparingTo("0")
   }
 
   @Test
@@ -119,8 +119,8 @@ class DocumentLineTest {
 
     assertThat(line.clientProductCode).isNull()
     assertThat(line.designation).isEqualTo("Copper Wire")
-    assertThat(line.unitPriceExclTax).isEqualByComparingTo("50.00")
-    assertThat(line.lineTotalExclTax).isEqualByComparingTo("50.00")
+    assertThat(line.unitPriceExclTax).isEqualByComparingTo("0")
+    assertThat(line.lineTotalExclTax).isEqualByComparingTo("0")
   }
 
   @Test

--- a/src/test/kotlin/fr/axl/lvy/order/OrderCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/order/OrderCodigServiceTest.kt
@@ -10,6 +10,7 @@ import fr.axl.lvy.fiscalposition.FiscalPositionService
 import fr.axl.lvy.paymentterm.PaymentTerm
 import fr.axl.lvy.paymentterm.PaymentTermRepository
 import fr.axl.lvy.product.Product
+import fr.axl.lvy.product.ProductPriceCompany
 import fr.axl.lvy.product.ProductRepository
 import fr.axl.lvy.sale.SalesCodig
 import fr.axl.lvy.sale.SalesCodigRepository
@@ -415,6 +416,9 @@ class OrderCodigServiceTest {
     mtoProduct.mto = true
     mtoProduct.sellingPriceExclTax = BigDecimal("100.00")
     mtoProduct.purchasePriceExclTax = BigDecimal("60.00")
+    mtoProduct.replacePurchasePrices(
+      listOf(Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("60.00"), "EUR"))
+    )
     productRepository.saveAndFlush(mtoProduct)
 
     val regularProduct = Product("PRD-REG", "Standard Part")

--- a/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
@@ -33,7 +33,6 @@ class ProductServiceTest {
     product.sellingCurrency = "USD"
     product.purchasePriceExclTax = BigDecimal("80.00")
     product.purchaseCurrency = "CNY"
-    product.priceType = "Prix départ usine"
     product.unit = "kg"
     productService.save(product)
 
@@ -48,7 +47,6 @@ class ProductServiceTest {
     assertThat(found.get().sellingPriceExclTax).isEqualByComparingTo("150.00")
     assertThat(found.get().sellingCurrency).isEqualTo("USD")
     assertThat(found.get().purchaseCurrency).isEqualTo("CNY")
-    assertThat(found.get().priceType).isEqualTo("Prix départ usine")
   }
 
   @Test
@@ -120,13 +118,6 @@ class ProductServiceTest {
 
     val found = productService.findById(product.id!!).orElseThrow()
     assertThat(found.mto).isFalse
-  }
-
-  @Test
-  fun default_price_type_is_blank() {
-    val product = Product("REF-PRICE-TYPE", "Price Type Product")
-
-    assertThat(product.priceType).isNull()
   }
 
   @Test

--- a/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/product/ProductServiceTest.kt
@@ -2,6 +2,7 @@ package fr.axl.lvy.product
 
 import fr.axl.lvy.client.Client
 import fr.axl.lvy.client.ClientRepository
+import fr.axl.lvy.documentline.DocumentLine
 import jakarta.persistence.EntityManager
 import java.math.BigDecimal
 import org.assertj.core.api.Assertions.assertThat
@@ -367,5 +368,247 @@ class ProductServiceTest {
     val found = productService.findDetailedById(product.id!!).orElseThrow()
     assertThat(found.findClientProductCode(found.clientProductCodes.first().client))
       .isEqualTo("DET-CLIENT-001")
+  }
+
+  private fun saveProductWithPrices(
+    ref: String,
+    purchasePrices: List<Product.PurchasePriceEntry> = emptyList(),
+    sellingPrices: List<Product.SellingPriceEntry> = emptyList(),
+  ): Product {
+    val product = Product(ref, "Product $ref")
+    product.replacePurchasePrices(purchasePrices)
+    product.replaceSellingPrices(sellingPrices)
+    productService.save(product)
+    productRepository.flush()
+    return product
+  }
+
+  @Test
+  fun save_persists_purchase_prices_per_company() {
+    val product =
+      saveProductWithPrices(
+        "REF-PP-1",
+        purchasePrices =
+          listOf(
+            Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("10.00"), "EUR"),
+            Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("12.00"), "USD"),
+          ),
+      )
+
+    assertThat(
+        productService.findPurchasePrice(product.id, ProductPriceCompany.CODIG)?.priceExclTax
+      )
+      .isEqualByComparingTo("10.00")
+    assertThat(productService.findPurchasePrice(product.id, ProductPriceCompany.NETSTONE)?.currency)
+      .isEqualTo("USD")
+  }
+
+  @Test
+  fun save_persists_selling_prices_per_client() {
+    val client = createClient("CLI-SP-1")
+    val product =
+      saveProductWithPrices(
+        "REF-SP-1",
+        sellingPrices = listOf(Product.SellingPriceEntry(client, BigDecimal("99.00"), "EUR")),
+      )
+
+    val resolved = productService.findSellingPrice(product.id, client.id!!)
+    assertThat(resolved?.priceExclTax).isEqualByComparingTo("99.00")
+    assertThat(resolved?.currency).isEqualTo("EUR")
+  }
+
+  @Test
+  fun replacePurchasePrices_updates_existing_and_adds_and_removes() {
+    val product =
+      saveProductWithPrices(
+        "REF-PP-2",
+        purchasePrices =
+          listOf(Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("10.00"), "EUR")),
+      )
+
+    val loaded = productService.findDetailedById(product.id!!).orElseThrow()
+    loaded.replacePurchasePrices(
+      listOf(
+        Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("20.00"), "USD"),
+        Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("15.00"), "EUR"),
+      )
+    )
+    productService.save(loaded)
+    productRepository.flush()
+
+    val codig = productService.findPurchasePrice(product.id, ProductPriceCompany.CODIG)
+    val netstone = productService.findPurchasePrice(product.id, ProductPriceCompany.NETSTONE)
+    assertThat(codig?.priceExclTax).isEqualByComparingTo("20.00")
+    assertThat(codig?.currency).isEqualTo("USD")
+    assertThat(netstone?.priceExclTax).isEqualByComparingTo("15.00")
+
+    val reloaded = productService.findDetailedById(product.id!!).orElseThrow()
+    reloaded.replacePurchasePrices(emptyList())
+    productService.save(reloaded)
+    productRepository.flush()
+
+    assertThat(productService.findPurchasePrice(product.id, ProductPriceCompany.CODIG)).isNull()
+    assertThat(productService.findPurchasePrice(product.id, ProductPriceCompany.NETSTONE)).isNull()
+  }
+
+  @Test
+  fun replaceSellingPrices_updates_existing_and_adds_and_removes() {
+    val clientA = createClient("CLI-SP-A")
+    val clientB = createClient("CLI-SP-B")
+    val product =
+      saveProductWithPrices(
+        "REF-SP-2",
+        sellingPrices = listOf(Product.SellingPriceEntry(clientA, BigDecimal("50.00"), "EUR")),
+      )
+
+    val loaded = productService.findDetailedById(product.id!!).orElseThrow()
+    loaded.replaceSellingPrices(
+      listOf(
+        Product.SellingPriceEntry(clientA, BigDecimal("55.00"), "USD"),
+        Product.SellingPriceEntry(clientB, BigDecimal("60.00"), "EUR"),
+      )
+    )
+    productService.save(loaded)
+    productRepository.flush()
+
+    assertThat(productService.findSellingPrice(product.id, clientA.id!!)?.priceExclTax)
+      .isEqualByComparingTo("55.00")
+    assertThat(productService.findSellingPrice(product.id, clientB.id!!)?.priceExclTax)
+      .isEqualByComparingTo("60.00")
+
+    val reloaded = productService.findDetailedById(product.id!!).orElseThrow()
+    reloaded.replaceSellingPrices(
+      listOf(Product.SellingPriceEntry(clientB, BigDecimal("60.00"), "EUR"))
+    )
+    productService.save(reloaded)
+    productRepository.flush()
+
+    assertThat(productService.findSellingPrice(product.id, clientA.id!!)).isNull()
+    assertThat(productService.findSellingPrice(product.id, clientB.id!!)).isNotNull
+  }
+
+  @Test
+  fun replaceSellingPrices_skips_clients_without_id() {
+    val clientWithoutId = Client("CLI-SP-NOID", "No-id client")
+    val product = Product("REF-SP-NOID", "Product no-id client")
+    product.replaceSellingPrices(
+      listOf(Product.SellingPriceEntry(clientWithoutId, BigDecimal("10.00"), "EUR"))
+    )
+
+    assertThat(product.sellingPrices).isEmpty()
+  }
+
+  @Test
+  fun findPurchasePrice_returns_null_for_null_product_id() {
+    assertThat(productService.findPurchasePrice(null, ProductPriceCompany.CODIG)).isNull()
+  }
+
+  @Test
+  fun findSellingPrice_returns_null_for_null_product_id() {
+    assertThat(productService.findSellingPrice(null, 1L)).isNull()
+  }
+
+  @Test
+  fun resolveUnitPrice_orderCodig_uses_codig_purchase_price() {
+    val product =
+      saveProductWithPrices(
+        "REF-RU-1",
+        purchasePrices =
+          listOf(
+            Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("11.00"), "EUR"),
+            Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("99.00"), "EUR"),
+          ),
+      )
+
+    assertThat(productService.resolveUnitPrice(DocumentLine.DocumentType.ORDER_CODIG, product))
+      .isEqualByComparingTo("11.00")
+    assertThat(productService.resolveCurrency(DocumentLine.DocumentType.ORDER_CODIG, product))
+      .isEqualTo("EUR")
+  }
+
+  @Test
+  fun resolveUnitPrice_salesCodig_uses_client_selling_price() {
+    val client = createClient("CLI-RU-2")
+    val product =
+      saveProductWithPrices(
+        "REF-RU-2",
+        sellingPrices = listOf(Product.SellingPriceEntry(client, BigDecimal("77.00"), "USD")),
+      )
+
+    assertThat(
+        productService.resolveUnitPrice(DocumentLine.DocumentType.SALES_CODIG, product, client)
+      )
+      .isEqualByComparingTo("77.00")
+    assertThat(
+        productService.resolveCurrency(DocumentLine.DocumentType.INVOICE_CODIG, product, client)
+      )
+      .isEqualTo("USD")
+  }
+
+  @Test
+  fun resolveUnitPrice_salesCodig_returns_null_without_client() {
+    val product = saveProductWithPrices("REF-RU-3")
+    assertThat(productService.resolveUnitPrice(DocumentLine.DocumentType.SALES_CODIG, product))
+      .isNull()
+    assertThat(productService.resolveCurrency(DocumentLine.DocumentType.SALES_CODIG, product))
+      .isNull()
+  }
+
+  @Test
+  fun resolveUnitPrice_netstone_documents_use_netstone_purchase_price() {
+    val product =
+      saveProductWithPrices(
+        "REF-RU-4",
+        purchasePrices =
+          listOf(
+            Product.PurchasePriceEntry(ProductPriceCompany.NETSTONE, BigDecimal("33.00"), "USD")
+          ),
+      )
+
+    listOf(
+        DocumentLine.DocumentType.SALES_NETSTONE,
+        DocumentLine.DocumentType.ORDER_NETSTONE,
+        DocumentLine.DocumentType.INVOICE_NETSTONE,
+        DocumentLine.DocumentType.DELIVERY_NETSTONE,
+      )
+      .forEach { type ->
+        assertThat(productService.resolveUnitPrice(type, product))
+          .`as`("unitPrice for $type")
+          .isEqualByComparingTo("33.00")
+        assertThat(productService.resolveCurrency(type, product))
+          .`as`("currency for $type")
+          .isEqualTo("USD")
+      }
+  }
+
+  @Test
+  fun resolveUnitPrice_with_usePurchasePrice_overrides_to_codig_purchase() {
+    val client = createClient("CLI-RU-5")
+    val product =
+      saveProductWithPrices(
+        "REF-RU-5",
+        purchasePrices =
+          listOf(Product.PurchasePriceEntry(ProductPriceCompany.CODIG, BigDecimal("44.00"), "EUR")),
+        sellingPrices = listOf(Product.SellingPriceEntry(client, BigDecimal("99.00"), "USD")),
+      )
+
+    assertThat(
+        productService.resolveUnitPrice(
+          DocumentLine.DocumentType.SALES_CODIG,
+          product,
+          client,
+          usePurchasePrice = true,
+        )
+      )
+      .isEqualByComparingTo("44.00")
+    assertThat(
+        productService.resolveCurrency(
+          DocumentLine.DocumentType.SALES_CODIG,
+          product,
+          client,
+          usePurchasePrice = true,
+        )
+      )
+      .isEqualTo("EUR")
   }
 }

--- a/src/test/kotlin/fr/axl/lvy/sale/SalesCodigServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/sale/SalesCodigServiceTest.kt
@@ -177,7 +177,8 @@ class SalesCodigServiceTest {
     assertThat(order.orderNumber).startsWith("CoD_PO_")
     assertThat(order.client.id).isEqualTo(supplier.id)
     assertThat(order.subject).isEqualTo("Test Subject")
-    assertThat(order.currency).isEqualTo("USD")
+    // Purchase price currency overrides sale currency on generated order
+    assertThat(order.currency).isEqualTo("EUR")
     // incoterms comes from codigCompany.incoterm (null in this test — no incoterm configured)
     // incotermLocation comes from sale.client.deliveryPort (null in this test — no deliveryPort
     // set)

--- a/src/test/kotlin/fr/axl/lvy/sale/SalesNetstoneServiceTest.kt
+++ b/src/test/kotlin/fr/axl/lvy/sale/SalesNetstoneServiceTest.kt
@@ -152,7 +152,8 @@ class SalesNetstoneServiceTest {
     assertThat(result.orderNetstone).isNull()
     assertThat(result.incotermLocation).isEqualTo("Le Havre")
     assertThat(result.fiscalPosition?.position).isEqualTo("Fiscalite Netstone")
-    assertThat(result.currency).isEqualTo("USD")
+    // Purchase price currency overrides sale currency on generated salesNetstone
+    assertThat(result.currency).isEqualTo("EUR")
 
     val salesNetstoneLines =
       documentLineRepository.findByDocumentTypeAndDocumentIdOrderByPosition(


### PR DESCRIPTION
ajout d’un modèle de tarifs dédié avec prix d’achat par société CoDIG / Netstone et prix de vente CoDIG par client
•
refonte de la fiche produit pour gérer plusieurs prix d’achat et plusieurs prix de vente client
•
ajout des champs CAS et EC dans la fiche produit
•
suppression du champ conditions prix d'achat
•
adaptation du préremplissage des lignes de vente, commande et facture pour utiliser les nouveaux tarifs au lieu des anciens prix globaux produit
•
mise à jour des calculs de coûts d’achat sur les ventes et commandes générées
•
correction du chargement Hibernate de la fiche produit pour éviter le MultipleBagFetchException
•
migration des téléchargements PDF Vaadin de StreamResource vers DownloadHandler
•
ajustements livraison Netstone/CoDIG pour gérer plusieurs lots et plusieurs numéros de conteneur dans la saisie et les PDFs